### PR TITLE
Run test functions in parallel |  Replace Assert with Require | Remove if statements

### DIFF
--- a/tests/cli_tests/zboxcli_multisig_wallet_test.go
+++ b/tests/cli_tests/zboxcli_multisig_wallet_test.go
@@ -3,7 +3,8 @@ package cli_tests
 import (
 	"fmt"
 	"github.com/0chain/system_test/internal/cli/util"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
 )
 
@@ -16,17 +17,18 @@ func TestMultisigWallet(t *testing.T) {
 			numSigners, threshold := 3, 2
 
 			output, err := createMultiSigWallet(t, configPath, numSigners, threshold)
-			assert.Nil(t, err)
+			require.Nil(t, err, "error occurred creating multisig wallet", strings.Join(output, "\n"))
 
 			//FIXME: POSSIBLE BUG - blank wallet being created despite it not being used in the multisig create process
-			assert.Equal(t, "No wallet in path  ./config/TestMultisigWallet-parallel-Wallet_Creation_should_succeed_when_0_LESS_THAN_threshold_LESS_THAN=_num-signers_wallet.json found. Creating wallet...", output[0])
-			assert.Equal(t, "ZCN wallet created!!", output[1])
-			assert.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
-			assert.Equal(t, "Read pool created successfully", output[3])
+			require.True(t, len(output) > 4, "Output was less than number of assertions")
+			require.Equal(t, "No wallet in path  ./config/TestMultisigWallet-parallel-Wallet_Creation_should_succeed_when_0_LESS_THAN_threshold_LESS_THAN=_num-signers_wallet.json found. Creating wallet...", output[0])
+			require.Equal(t, "ZCN wallet created!!", output[1])
+			require.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
+			require.Equal(t, "Read pool created successfully", output[3])
 
 			// Total registered wallets = numsigners + 1 (additional wallet for multi-sig)
-			assert.Equal(t, fmt.Sprintf("registering %d wallets", numSigners+1), output[4])
-			assert.Equal(t, "Creating and testing a multisig wallet is successful!", output[len(output)-1])
+			require.Equal(t, fmt.Sprintf("registering %d wallets", numSigners+1), output[4])
+			require.Equal(t, "Creating and testing a multisig wallet is successful!", output[len(output)-1])
 		})
 
 		t.Run("Wallet Creation should succeed when threshold is equal to num-signers", func(t *testing.T) {
@@ -34,17 +36,17 @@ func TestMultisigWallet(t *testing.T) {
 			numSigners, threshold := 3, 3
 
 			output, err := createMultiSigWallet(t, configPath, numSigners, threshold)
-			assert.Nil(t, err)
 
-			//FIXME: POSSIBLE BUG - blank wallet being created despite it not being used in the multisig create process
-			assert.Equal(t, "No wallet in path  ./config/TestMultisigWallet-parallel-Wallet_Creation_should_succeed_when_threshold_is_equal_to_num-signers_wallet.json found. Creating wallet...", output[0])
-			assert.Equal(t, "ZCN wallet created!!", output[1])
-			assert.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
-			assert.Equal(t, "Read pool created successfully", output[3])
+			require.Nil(t, err, "error occurred creating multisig wallet", strings.Join(output, "\n"))
+			require.True(t, len(output) > 4, "Output was less than number of assertions")
+			require.Equal(t, "No wallet in path  ./config/TestMultisigWallet-parallel-Wallet_Creation_should_succeed_when_threshold_is_equal_to_num-signers_wallet.json found. Creating wallet...", output[0])
+			require.Equal(t, "ZCN wallet created!!", output[1])
+			require.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
+			require.Equal(t, "Read pool created successfully", output[3])
 
 			// Total registered wallets = numsigners + 1 (additional wallet for multi-sig)
-			assert.Equal(t, fmt.Sprintf("registering %d wallets", numSigners+1), output[4])
-			assert.Equal(t, "Creating and testing a multisig wallet is successful!", output[len(output)-1])
+			require.Equal(t, fmt.Sprintf("registering %d wallets", numSigners+1), output[4])
+			require.Equal(t, "Creating and testing a multisig wallet is successful!", output[len(output)-1])
 		})
 
 		t.Run("Wallet Creation should fail when threshold is 0", func(t *testing.T) {
@@ -52,15 +54,15 @@ func TestMultisigWallet(t *testing.T) {
 			numSigners, threshold := 3, 0
 
 			output, err := createMultiSigWallet(t, configPath, numSigners, threshold)
-			assert.NotNil(t, err)
 
-			//FIXME: POSSIBLE BUG - blank wallet being created despite it not being used in the multisig create process
-			assert.Equal(t, "ZCN wallet created!!", output[1])
-			assert.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
-			assert.Equal(t, "Read pool created successfully", output[3])
+			require.NotNil(t, err, "expected error to occur creating a multisig wallet", strings.Join(output, "\n"))
+			require.True(t, len(output) > 4, "Output was less than number of assertions")
+			require.Equal(t, "ZCN wallet created!!", output[1])
+			require.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
+			require.Equal(t, "Read pool created successfully", output[3])
 
 			//FIXME: BUG - panic: runtime error: index out of range [0] with length 0
-			assert.Equal(t, "panic: runtime error: index out of range [0] with length 0", output[4])
+			require.Equal(t, "panic: runtime error: index out of range [0] with length 0", output[4])
 		})
 
 		t.Run("Wallet Creation should fail when threshold is -1", func(t *testing.T) {
@@ -68,15 +70,15 @@ func TestMultisigWallet(t *testing.T) {
 			numSigners, threshold := 3, -1
 
 			output, err := createMultiSigWallet(t, configPath, numSigners, threshold)
-			assert.NotNil(t, err)
 
-			//FIXME: POSSIBLE BUG - blank wallet being created despite it not being used in the multisig create process
-			assert.Equal(t, "ZCN wallet created!!", output[1])
-			assert.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
-			assert.Equal(t, "Read pool created successfully", output[3])
+			require.NotNil(t, err, "expected error to occur creating a multisig wallet", strings.Join(output, "\n"))
+			require.True(t, len(output) > 4, "Output was less than number of assertions")
+			require.Equal(t, "ZCN wallet created!!", output[1])
+			require.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
+			require.Equal(t, "Read pool created successfully", output[3])
 
 			//FIXME: BUG - panic: runtime error: makeslice: len out of range
-			assert.Equal(t, "panic: runtime error: makeslice: len out of range", output[4])
+			require.Equal(t, "panic: runtime error: makeslice: len out of range", output[4])
 		})
 
 		t.Run("Wallet Creation should fail when signers is < 2", func(t *testing.T) {
@@ -84,14 +86,14 @@ func TestMultisigWallet(t *testing.T) {
 			numSigners, threshold := 1, 1
 
 			output, err := createMultiSigWallet(t, configPath, numSigners, threshold)
-			assert.NotNil(t, err)
 
-			//FIXME: POSSIBLE BUG - blank wallet being created despite it not being used in the multisig create process
-			assert.Equal(t, "ZCN wallet created!!", output[1])
-			assert.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
-			assert.Equal(t, "Read pool created successfully", output[3])
+			require.NotNil(t, err, "expected error to occur creating a multisig wallet", strings.Join(output, "\n"))
+			require.True(t, len(output) > 4, "Output was less than number of assertions")
+			require.Equal(t, "ZCN wallet created!!", output[1])
+			require.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
+			require.Equal(t, "Read pool created successfully", output[3])
 
-			assert.Equal(t, "Error: too few signers. Minimum numsigners required is 2", output[4])
+			require.Equal(t, "Error: too few signers. Minimum numsigners required is 2", output[4])
 		})
 
 		t.Run("Wallet Creation should fail when threshold is greater than num-signers", func(t *testing.T) {
@@ -99,40 +101,43 @@ func TestMultisigWallet(t *testing.T) {
 			numSigners, threshold := 3, 4
 
 			output, err := createMultiSigWallet(t, configPath, numSigners, threshold)
-			assert.NotNil(t, err)
 
-			assert.Equal(t, "No wallet in path  ./config/TestMultisigWallet-parallel-Wallet_Creation_should_fail_when_threshold_is_greater_than_num-signers_wallet.json found. Creating wallet...", output[0])
-			assert.Equal(t, "ZCN wallet created!!", output[1])
-			assert.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
-			assert.Equal(t, "Read pool created successfully", output[3])
+			require.NotNil(t, err, "expected error to occur creating a multisig wallet", strings.Join(output, "\n"))
+			require.True(t, len(output) > 4, "Output was less than number of assertions")
+			require.Equal(t, "No wallet in path  ./config/TestMultisigWallet-parallel-Wallet_Creation_should_fail_when_threshold_is_greater_than_num-signers_wallet.json found. Creating wallet...", output[0])
+			require.Equal(t, "ZCN wallet created!!", output[1])
+			require.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
+			require.Equal(t, "Read pool created successfully", output[3])
 
-			assert.Equal(t, fmt.Sprintf("Error: given threshold (%d) is too high. Threshold has to be less than or equal to numsigners (%d)", threshold, numSigners), output[4])
+			require.Equal(t, fmt.Sprintf("Error: given threshold (%d) is too high. Threshold has to be less than or equal to numsigners (%d)", threshold, numSigners), output[4])
 		})
 
 		t.Run("Wallet Creation should fail when args not set", func(t *testing.T) {
 			t.Parallel()
 
 			output, err := cli_utils.RunCommand(fmt.Sprintf("./zwallet createmswallet --silent --wallet %s --configDir ./config --config %s", escapedTestName(t)+"_wallet.json", configPath))
-			assert.NotNil(t, err)
 
-			assert.Equal(t, "ZCN wallet created!!", output[1])
-			assert.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
-			assert.Equal(t, "Read pool created successfully", output[3])
+			require.NotNil(t, err, "expected command to fail", strings.Join(output, "\n"))
+			require.True(t, len(output) > 4, "Output was less than number of assertions")
+			require.Equal(t, "ZCN wallet created!!", output[1])
+			require.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
+			require.Equal(t, "Read pool created successfully", output[3])
 
-			assert.Equal(t, "Error: numsigners flag is missing", output[4])
+			require.Equal(t, "Error: numsigners flag is missing", output[4])
 		})
 
 		t.Run("Wallet Creation should fail when threshold not set", func(t *testing.T) {
 			t.Parallel()
 
 			output, err := cli_utils.RunCommand(fmt.Sprintf("./zwallet createmswallet --numsigners %d --silent --wallet %s --configDir ./config --config %s", 3, escapedTestName(t)+"_wallet.json", configPath))
-			assert.NotNil(t, err)
 
-			assert.Equal(t, "ZCN wallet created!!", output[1])
-			assert.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
-			assert.Equal(t, "Read pool created successfully", output[3])
+			require.NotNil(t, err, "expected command to fail", strings.Join(output, "\n"))
+			require.True(t, len(output) > 4, "Output was less than number of assertions")
+			require.Equal(t, "ZCN wallet created!!", output[1])
+			require.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
+			require.Equal(t, "Read pool created successfully", output[3])
 
-			assert.Equal(t, "Error: threshold flag is missing", output[4])
+			require.Equal(t, "Error: threshold flag is missing", output[4])
 		})
 	})
 

--- a/tests/cli_tests/zboxcli_recover_wallet_test.go
+++ b/tests/cli_tests/zboxcli_recover_wallet_test.go
@@ -2,7 +2,8 @@ package cli_tests
 
 import (
 	"github.com/0chain/system_test/internal/cli/util"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
 )
 
@@ -13,40 +14,42 @@ func TestRecoverWallet(t *testing.T) {
 		t.Run("Recover wallet valid mnemonic", func(t *testing.T) {
 			t.Parallel()
 			validMnemonic := "pull floor crop best weasel suit solid gown filter kitten loan absent noodle nation potato planet demise online ten affair rich panel rent sell"
-			output, err := recoverWalletFromMnemonic(t, configPath, validMnemonic)
-			if err != nil {
-				t.Errorf("error occured recovering a wallet  %v", err)
-			}
 
-			message := output[len(output)-1]
-			assert.Equal(t, "Wallet recovered!!", message)
+			output, err := recoverWalletFromMnemonic(t, configPath, validMnemonic)
+
+			require.Nil(t, err, "error occurred recovering a wallet", strings.Join(output, "\n"))
+			require.Equal(t, 5, len(output))
+			require.Equal(t, "Wallet recovered!!", output[len(output)-1])
 		})
 
-		//FIXME: POSSIBLE BUG: Blank wallet created if mnemonic is invalid
+		//FIXME: POSSIBLE BUG: Blank wallet created if mnemonic is invalid (same issue in missing mnemonic test)
 		t.Run("Recover wallet invalid mnemonic", func(t *testing.T) {
 			t.Parallel()
 			inValidMnemonic := "floor crop best weasel suit solid gown filter kitten loan absent noodle nation potato planet demise online ten affair rich panel rent sell"
+
 			output, err := recoverWalletFromMnemonic(t, configPath, inValidMnemonic)
-			assert.NotNil(t, err)
-			assert.Equal(t, 5, len(output))
-			assert.Equal(t, "No wallet in path  ./config/TestRecoverWallet-parallel-Recover_wallet_invalid_mnemonic_wallet.json found. Creating wallet...", output[0])
-			assert.Equal(t, "ZCN wallet created!!", output[1])
-			assert.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
-			assert.Equal(t, "Read pool created successfully", output[3])
-			assert.Equal(t, "Error: Invalid mnemonic", output[4])
+
+			require.NotNil(t, err, "expected error to occur recovering a wallet", strings.Join(output, "\n"))
+			require.Equal(t, 5, len(output))
+			require.Equal(t, "No wallet in path  ./config/TestRecoverWallet-parallel-Recover_wallet_invalid_mnemonic_wallet.json found. Creating wallet...", output[0])
+			require.Equal(t, "ZCN wallet created!!", output[1])
+			require.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
+			require.Equal(t, "Read pool created successfully", output[3])
+			require.Equal(t, "Error: Invalid mnemonic", output[4])
 		})
 
-		//FIXME: POSSIBLE BUG: Blank wallet created if mnemonic is missing
 		t.Run("Recover wallet no mnemonic", func(t *testing.T) {
 			t.Parallel()
+
 			output, err := cli_utils.RunCommand("./zwallet recoverwallet --silent --wallet " + escapedTestName(t) + "_wallet.json" + " --configDir ./config --config " + configPath)
-			assert.NotNil(t, err)
-			assert.Equal(t, 5, len(output))
-			assert.Equal(t, "No wallet in path  ./config/TestRecoverWallet-parallel-Recover_wallet_no_mnemonic_wallet.json found. Creating wallet...", output[0])
-			assert.Equal(t, "ZCN wallet created!!", output[1])
-			assert.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
-			assert.Equal(t, "Read pool created successfully", output[3])
-			assert.Equal(t, "Error: Mnemonic not provided", output[4])
+
+			require.NotNil(t, err, "expected error to occur recovering a wallet", strings.Join(output, "\n"))
+			require.Equal(t, 5, len(output))
+			require.Equal(t, "No wallet in path  ./config/TestRecoverWallet-parallel-Recover_wallet_no_mnemonic_wallet.json found. Creating wallet...", output[0])
+			require.Equal(t, "ZCN wallet created!!", output[1])
+			require.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
+			require.Equal(t, "Read pool created successfully", output[3])
+			require.Equal(t, "Error: Mnemonic not provided", output[4])
 		})
 	})
 }

--- a/tests/cli_tests/zwalletcli_send_and_balance_test.go
+++ b/tests/cli_tests/zwalletcli_send_and_balance_test.go
@@ -2,7 +2,7 @@ package cli_tests
 
 import (
 	"github.com/0chain/system_test/internal/cli/util"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"regexp"
 	"strings"
 	"testing"
@@ -17,74 +17,52 @@ func TestSendAndBalance(t *testing.T) {
 
 			targetWallet := escapedTestName(t) + "_TARGET"
 
-			if output, err := registerWallet(t, configPath); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err := registerWallet(t, configPath)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
-			if output, err := registerWalletForName(configPath, targetWallet); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = registerWalletForName(configPath, targetWallet)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
 			target, err := getWalletForName(t, configPath, targetWallet)
-			if err != nil {
-				t.Errorf("Error occured when retrieving target wallet due to error: %v", err)
-				return
-			}
+			require.Nil(t, err, "Error occurred when retrieving target wallet")
 
-			if output, err := executeFaucet(t, configPath); err != nil {
-				t.Errorf("Unexpected faucet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = executeFaucet(t, configPath)
+			require.Nil(t, err, "Unexpected faucet failure", strings.Join(output, "\n"))
 
 			successfulBalanceOutputRegex := regexp.MustCompile(`Balance: 1.000 ZCN \([0-9]*\.?[0-9]+ USD\)$`)
 
 			// Before send balance checks
-			output, err := getBalance(t, configPath)
-			if err != nil {
-				t.Errorf("Unexpected balance check failure for wallet %s: Output %v", escapedTestName(t), strings.Join(output, "\n"))
-			}
+			output, err = getBalance(t, configPath)
+			require.Nil(t, err, "Unexpected balance check failure for wallet", escapedTestName(t), strings.Join(output, "\n"))
 
-			assert.Equal(t, 1, len(output))
-			assert.Regexp(t, successfulBalanceOutputRegex, output[0])
+			require.Equal(t, 1, len(output))
+			require.Regexp(t, successfulBalanceOutputRegex, output[0])
 
 			output, err = getBalanceForWallet(configPath, targetWallet)
-			if err == nil {
-				t.Errorf("Missing expected balance check failure for wallet %s: Output %v", targetWallet, strings.Join(output, "\n"))
-				return
-			}
+			require.NotNil(t, err, "Missing expected balance check failure for wallet", targetWallet, strings.Join(output, "\n"))
 
-			assert.Equal(t, 1, len(output))
-			assert.Equal(t, "Failed to get balance:", output[0])
+			require.Equal(t, 1, len(output))
+			require.Equal(t, "Failed to get balance:", output[0])
 
 			// Transfer ZCN from sender to target wallet
 			output, err = sendZCN(t, configPath, target.ClientId, "1", "transfer")
-			if err != nil {
-				t.Errorf("Unexpected send failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			require.Nil(t, err, "Unexpected send failure", strings.Join(output, "\n"))
 
-			assert.Len(t, output, 1)
-			assert.Equal(t, "Send tokens success", output[0])
+			require.Len(t, output, 1)
+			require.Equal(t, "Send tokens success", output[0])
 
 			// After send balance checks
 			output, err = getBalance(t, configPath)
-			if err == nil {
-				t.Errorf("Missing expected balance check failure for wallet %s: Output %v", escapedTestName(t), strings.Join(output, "\n"))
-				return
-			}
+			require.NotNil(t, err, "Missing expected balance check failure for wallet", escapedTestName(t), strings.Join(output, "\n"))
 
-			assert.Equal(t, 1, len(output))
-			assert.Equal(t, "Failed to get balance:", output[0])
+			require.Equal(t, 1, len(output))
+			require.Equal(t, "Failed to get balance:", output[0])
 
 			output, err = getBalanceForWallet(configPath, targetWallet)
-			if err != nil {
-				t.Errorf("Unexpected balance check failure for wallet %s: Output %v", targetWallet, strings.Join(output, "\n"))
-			}
+			require.Nil(t, err, "Unexpected balance check failure for wallet", targetWallet, strings.Join(output, "\n"))
 
-			assert.Equal(t, 1, len(output))
-			assert.Regexp(t, successfulBalanceOutputRegex, output[0])
+			require.Equal(t, 1, len(output))
+			require.Regexp(t, successfulBalanceOutputRegex, output[0])
 		})
 
 		t.Run("Send with description", func(t *testing.T) {
@@ -92,277 +70,183 @@ func TestSendAndBalance(t *testing.T) {
 
 			targetWallet := escapedTestName(t) + "_TARGET"
 
-			if output, err := registerWallet(t, configPath); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err := registerWallet(t, configPath)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
-			if output, err := registerWalletForName(configPath, targetWallet); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = registerWalletForName(configPath, targetWallet)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
 			target, err := getWalletForName(t, configPath, targetWallet)
-			if err != nil {
-				t.Errorf("Error occured when retrieving target wallet due to error: %v", err)
-				return
-			}
+			require.Nil(t, err, "Error occurred when retrieving target wallet")
 
-			if output, err := executeFaucet(t, configPath); err != nil {
-				t.Errorf("Unexpected faucet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = executeFaucet(t, configPath)
+			require.Nil(t, err, "Unexpected faucet failure", strings.Join(output, "\n"))
 
-			output, err := sendZCN(t, configPath, target.ClientId, "1", "rich description")
-			if err != nil {
-				t.Errorf("Unexpected send failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = sendZCN(t, configPath, target.ClientId, "1", "rich description")
+			require.Nil(t, err, "Unexpected send failure", strings.Join(output, "\n"))
 
-			assert.Len(t, output, 1)
-			assert.Equal(t, "Send tokens success", output[0])
+			require.Len(t, output, 1)
+			require.Equal(t, "Send tokens success", output[0])
 			// cannot verify transaction payload at this moment due to transaction hash not being printed.
 		})
 
-		t.Run("Send without description", func(t *testing.T) {
+		t.Run("Send without description should fail", func(t *testing.T) {
+			t.Parallel()
+
+			output, err := registerWallet(t, configPath)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
+
+			output, err = cli_utils.RunCommand("./zwallet send --silent --tokens 1" +
+				" --to_client_id 7ec733204418d72b68e3579bdf55881b1528c676850976920de3f73e45d4fafa" +
+				" --wallet " + escapedTestName(t) + "_wallet.json --configDir ./config --config " + configPath,
+			)
+			require.NotNil(t, err, "Expected send to fail", strings.Join(output, "\n"))
+
+			require.Len(t, output, 1)
+			require.Equal(t, "Error: Description flag is missing", output[0])
+			// cannot verify transaction payload at this moment due to transaction hash not being printed.
+		})
+
+		t.Run("Send attempt on zero ZCN wallet should fail", func(t *testing.T) {
 			t.Parallel()
 
 			targetWallet := escapedTestName(t) + "_TARGET"
 
-			if output, err := registerWallet(t, configPath); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err := registerWallet(t, configPath)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
-			if output, err := registerWalletForName(configPath, targetWallet); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = registerWalletForName(configPath, targetWallet)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
 			target, err := getWalletForName(t, configPath, targetWallet)
-			if err != nil {
-				t.Errorf("Error occured when retrieving target wallet due to error: %v", err)
-				return
-			}
-
-			if output, err := executeFaucet(t, configPath); err != nil {
-				t.Errorf("Unexpected faucet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
-
-			output, err := sendZCN(t, configPath, target.ClientId, "1", "")
-			if err != nil {
-				t.Errorf("Unexpected send failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
-
-			assert.Len(t, output, 1)
-			assert.Equal(t, "Send tokens success", output[0])
-			// cannot verify transaction payload at this moment due to transaction hash not being printed.
-		})
-
-		t.Run("Send attempt on zero ZCN wallet", func(t *testing.T) {
-			t.Parallel()
-
-			targetWallet := escapedTestName(t) + "_TARGET"
-
-			if output, err := registerWallet(t, configPath); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
-
-			if output, err := registerWalletForName(configPath, targetWallet); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
-
-			target, err := getWalletForName(t, configPath, targetWallet)
-			if err != nil {
-				t.Errorf("Error occured when retrieving target wallet due to error: %v", err)
-				return
-			}
+			require.Nil(t, err, "Error occurred when retrieving target wallet")
 
 			wantFailureMsg := "Send tokens failed. {\"error\": \"verify transaction failed\"}"
 
-			output, err := sendZCN(t, configPath, target.ClientId, "1", "")
-			if err == nil {
-				t.Errorf("Missing expected send failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = sendZCN(t, configPath, target.ClientId, "1", "")
+			require.NotNil(t, err, "Expected send to fail", strings.Join(output, "\n"))
 
-			assert.Len(t, output, 1)
-			assert.Equal(t, wantFailureMsg, output[0])
+			require.Len(t, output, 1)
+			require.Equal(t, wantFailureMsg, output[0])
 		})
 
-		t.Run("Send attempt to invalid address", func(t *testing.T) {
+		t.Run("Send attempt to invalid address should fail", func(t *testing.T) {
 			t.Parallel()
 
-			if output, err := registerWallet(t, configPath); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err := registerWallet(t, configPath)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
-			if output, err := executeFaucet(t, configPath); err != nil {
-				t.Errorf("Unexpected faucet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = executeFaucet(t, configPath)
+			require.Nil(t, err, "Unexpected faucet failure", strings.Join(output, "\n"))
 
 			invalidClientID := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabb" // more than 64 chars
 			wantFailureMsg := "Send tokens failed. submit transaction failed. {\"code\":\"invalid_request\"," +
 				"\"error\":\"invalid_request: Invalid request (to client id must be a hexadecimal hash)\"}"
 
-			output, err := sendZCN(t, configPath, invalidClientID, "1", "invalid address")
-			if err == nil {
-				t.Errorf("Missing expected send failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = sendZCN(t, configPath, invalidClientID, "1", "invalid_address")
+			require.NotNil(t, err, "Expected send to fail", strings.Join(output, "\n"))
 
-			assert.Len(t, output, 1)
-			assert.Equal(t, wantFailureMsg, output[0])
+			require.Len(t, output, 1)
+			require.Equal(t, wantFailureMsg, output[0])
 		})
 
 		/* FIXME - this and the exceeding balance test takes a long time to run because the CLI sends the txn and has to wait for it to fail
 		   it would be more efficient for the CLI to first run a balance check internally before sending the txn in order to fail fast
 		   https://github.com/0chain/zwalletcli/issues/52
 		*/
-		t.Run("Send with zero token", func(t *testing.T) {
+		t.Run("Send with zero token should fail", func(t *testing.T) {
 			t.Parallel()
 
 			targetWallet := escapedTestName(t) + "_TARGET"
 
-			if output, err := registerWallet(t, configPath); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err := registerWallet(t, configPath)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
-			if output, err := registerWalletForName(configPath, targetWallet); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = registerWalletForName(configPath, targetWallet)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
 			target, err := getWalletForName(t, configPath, targetWallet)
-			if err != nil {
-				t.Errorf("Error occured when retrieving target wallet due to error: %v", err)
-				return
-			}
+			require.Nil(t, err, "Error occurred when retrieving target wallet")
 
-			if output, err := executeFaucet(t, configPath); err != nil {
-				t.Errorf("Unexpected faucet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = executeFaucet(t, configPath)
+			require.Nil(t, err, "Unexpected faucet failure", strings.Join(output, "\n"))
 
-			output, err := sendZCN(t, configPath, target.ClientId, "0", "negative token")
-			if err != nil {
-				t.Errorf("Unexpected send failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = sendZCN(t, configPath, target.ClientId, "1", "negative token")
+			require.Nil(t, err, "Unexpected send failure", strings.Join(output, "\n"))
 
-			assert.Len(t, output, 1)
-			assert.Equal(t, "Send tokens success", output[0])
+			require.Len(t, output, 1)
+			require.Equal(t, "Send tokens success", output[0])
 		})
 
-		t.Run("Send attempt to exceeding balance", func(t *testing.T) {
+		t.Run("Send attempt to exceeding balance should fail", func(t *testing.T) {
 			t.Parallel()
 
 			targetWallet := escapedTestName(t) + "_TARGET"
 
-			if output, err := registerWallet(t, configPath); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err := registerWallet(t, configPath)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
-			if output, err := registerWalletForName(configPath, targetWallet); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = registerWalletForName(configPath, targetWallet)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
 			target, err := getWalletForName(t, configPath, targetWallet)
-			if err != nil {
-				t.Errorf("Error occured when retrieving target wallet due to error: %v", err)
-				return
-			}
+			require.Nil(t, err, "Error occurred when retrieving target wallet")
 
-			if output, err := executeFaucet(t, configPath); err != nil {
-				t.Errorf("Unexpected faucet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = executeFaucet(t, configPath)
+			require.Nil(t, err, "Unexpected faucet failure", strings.Join(output, "\n"))
 
 			wantFailureMsg := "Send tokens failed. {\"error\": \"verify transaction failed\"}"
 
-			output, err := sendZCN(t, configPath, target.ClientId, "1.5", "exceed bal")
-			if err == nil {
-				t.Errorf("Missing expected send failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = sendZCN(t, configPath, target.ClientId, "1.5", "exceed bal")
+			require.NotNil(t, err, "Expected send to fail", strings.Join(output, "\n"))
 
-			assert.Len(t, output, 1)
-			assert.Equal(t, wantFailureMsg, output[0])
+			require.Len(t, output, 1)
+			require.Equal(t, wantFailureMsg, output[0])
 		})
 
-		t.Run("Send attempt with negative token", func(t *testing.T) {
+		t.Run("Send attempt with negative token should fail", func(t *testing.T) {
 			t.Parallel()
 
 			targetWallet := escapedTestName(t) + "_TARGET"
 
-			if output, err := registerWallet(t, configPath); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err := registerWallet(t, configPath)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
-			if output, err := registerWalletForName(configPath, targetWallet); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = registerWalletForName(configPath, targetWallet)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
 			target, err := getWalletForName(t, configPath, targetWallet)
-			if err != nil {
-				t.Errorf("Error occured when retrieving target wallet due to error: %v", err)
-				return
-			}
+			require.Nil(t, err, "Error occurred when retrieving target wallet")
 
-			if output, err := executeFaucet(t, configPath); err != nil {
-				t.Errorf("Unexpected faucet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = executeFaucet(t, configPath)
+			require.Nil(t, err, "Unexpected faucet failure", strings.Join(output, "\n"))
 
 			wantFailureMsg := "Send tokens failed. submit transaction failed. {\"code\":\"invalid_request\"," +
 				"\"error\":\"invalid_request: Invalid request (value must be greater than or equal to zero)\"}"
 
-			output, err := sendZCN(t, configPath, target.ClientId, "-1", "negative token")
-			if err == nil {
-				t.Errorf("Missing expected send failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = sendZCN(t, configPath, target.ClientId, "-1", "negative token")
+			require.NotNil(t, err, "Expected send to fail", strings.Join(output, "\n"))
 
-			assert.Len(t, output, 1)
-			assert.Equal(t, wantFailureMsg, output[0])
+			require.Len(t, output, 1)
+			require.Equal(t, wantFailureMsg, output[0])
 		})
 
-		t.Run("Send attempt with very long description", func(t *testing.T) {
+		t.Run("Send attempt with very long description should fail", func(t *testing.T) {
 			t.Parallel()
 
 			targetWallet := escapedTestName(t) + "_TARGET"
 
-			if output, err := registerWallet(t, configPath); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err := registerWallet(t, configPath)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
-			if output, err := registerWalletForName(configPath, targetWallet); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = registerWalletForName(configPath, targetWallet)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
 			target, err := getWalletForName(t, configPath, targetWallet)
-			if err != nil {
-				t.Errorf("Error occured when retrieving target wallet due to error: %v", err)
-				return
-			}
+			require.Nil(t, err, "Error occurred when retrieving target wallet")
 
-			if output, err := executeFaucet(t, configPath); err != nil {
-				t.Errorf("Unexpected faucet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = executeFaucet(t, configPath)
+			require.Nil(t, err, "Unexpected faucet failure", strings.Join(output, "\n"))
 
 			b := make([]rune, 100000)
 			for i := range b {
@@ -373,46 +257,33 @@ func TestSendAndBalance(t *testing.T) {
 			wantFailureMsg := "Send tokens failed. submit transaction failed. {\"code\":\"txn_exceed_max_payload\"," +
 				"\"error\":\"txn_exceed_max_payload: transaction payload exceeds the max payload (98304)\"}"
 
-			output, err := sendZCN(t, configPath, target.ClientId, "1", longDesc)
-			if err == nil {
-				t.Errorf("Missing expected send failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = sendZCN(t, configPath, target.ClientId, "1", longDesc)
+			require.NotNil(t, err, "Expected send to fail", strings.Join(output, "\n"))
 
-			assert.Len(t, output, 1)
-			assert.Equal(t, wantFailureMsg, output[0])
+			require.Len(t, output, 1)
+			require.Equal(t, wantFailureMsg, output[0])
 		})
 
-		t.Run("Send attempt to self", func(t *testing.T) {
+		t.Run("Send attempt to self should fail", func(t *testing.T) {
 			t.Parallel()
 
-			if output, err := registerWallet(t, configPath); err != nil {
-				t.Errorf("Unexpected register wallet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err := registerWallet(t, configPath)
+			require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
 
 			wallet, err := getWallet(t, configPath)
-			if err != nil {
-				t.Errorf("Error occured when retrieving target wallet due to error: %v", err)
-			}
+			require.Nil(t, err, "Get wallet failed", strings.Join(output, "\n"))
 
-			output, err := executeFaucet(t, configPath)
-			if err != nil {
-				t.Errorf("Unexpected faucet failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			output, err = executeFaucet(t, configPath)
+			require.Nil(t, err, "Unexpected faucet failure", strings.Join(output, "\n"))
 
 			wantFailureMsg := "Send tokens failed. submit transaction failed. {\"code\":\"invalid_request\"," +
 				"\"error\":\"invalid_request: Invalid request (from and to client should be different)\"}"
 
 			output, err = sendZCN(t, configPath, wallet.ClientId, "1", "send self")
-			if err == nil {
-				t.Errorf("Missing expected send failure: Output %v", strings.Join(output, "\n"))
-				return
-			}
+			require.NotNil(t, err, "Expected send to fail", strings.Join(output, "\n"))
 
-			assert.Len(t, output, 1)
-			assert.Equal(t, wantFailureMsg, output[0])
+			require.Len(t, output, 1)
+			require.Equal(t, wantFailureMsg, output[0])
 		})
 	})
 }


### PR DESCRIPTION
Previously all tests had to complete within a given test function before the test runner would move to the next function.
This means if you had 6 threads and 1 slow-running test, 5 threads could potentially be needlessly waiting.

This change runs ensures test functions run in parallel.
In the same situation as above, the 5 other threads will be free to execute tests in other test functions 

There is also the added benefit of test results all being displayed together at the end of the test run:
![image](https://user-images.githubusercontent.com/18306778/133864846-3545e558-f86a-4f52-b45d-59ec88061d60.png)
rather than scattered throughout

This change also [removes Assert and replaces it with Require](https://github.com/stretchr/testify/issues/301#issuecomment-213464175). This ensures our tests exit fast as soon as they encounter an assertion failure.
Previously, the test would continue and potentially cause a panic, bringing down the entire test suite eg:
![image](https://user-images.githubusercontent.com/18306778/133867887-3662bdf5-e4dc-417c-a12e-856db8e71d21.png)


Also removed if conditionals in favour of assertions 