### PR TITLE
Block rewards tests 

### DIFF
--- a/internal/api/model/model.go
+++ b/internal/api/model/model.go
@@ -1,0 +1,51 @@
+package apimodel
+
+type Balance struct {
+	Txn     string `json:"txn"`
+	Round   int64  `json:"round"`
+	Balance int64  `json:"balance"`
+}
+
+type Block struct {
+	Block struct {
+		Version                        string `json:"version"`
+		CreationDate                   int64  `json:"creation_date"`
+		LatestFinalizedMagicBlockHash  string `json:"latest_finalized_magic_block_hash"`
+		LatestFinalizedMagicBlockRound int64  `json:"latest_finalized_magic_block_round"`
+		PrevHash                       string `json:"prev_hash"`
+		PrevVerificationTickets        []struct {
+			VerifierId string `json:"verifier_id"`
+			Signature  string `json:"signature"`
+		} `json:"prev_verification_tickets"`
+		MinerId           string `json:"miner_id"`
+		Round             int64  `json:"round"`
+		RoundRandomSeed   int64  `json:"round_random_seed"`
+		RoundTimeoutCount int64  `json:"round_timeout_count"`
+		StateHash         string `json:"state_hash"`
+		Transactions      []struct {
+			Hash              string `json:"hash"`
+			Version           string `json:"version"`
+			ClientId          string `json:"client_id"`
+			ToClientId        string `json:"to_client_id"`
+			ChainId           string `json:"chain_id"`
+			TransactionData   string `json:"transaction_data"`
+			TransactionValue  int64  `json:"transaction_value"`
+			Signature         string `json:"signature"`
+			CreationDate      int64  `json:"creation_date"`
+			TransactionFee    int64  `json:"transaction_fee"`
+			TransactionType   int    `json:"transaction_type"`
+			TransactionOutput string `json:"transaction_output,omitempty"`
+			TxnOutputHash     string `json:"txn_output_hash"`
+			TransactionStatus int    `json:"transaction_status"`
+		} `json:"transactions"`
+		VerificationTickets []struct {
+			VerifierId string `json:"verifier_id"`
+			Signature  string `json:"signature"`
+		} `json:"verification_tickets"`
+		Hash            string  `json:"hash"`
+		Signature       string  `json:"signature"`
+		ChainId         string  `json:"chain_id"`
+		ChainWeight     float64 `json:"chain_weight"`
+		RunningTxnCount int     `json:"running_txn_count"`
+	} `json:"block"`
+}

--- a/internal/cli/model/model.go
+++ b/internal/cli/model/model.go
@@ -164,3 +164,45 @@ type LockedInterestPoolStat struct {
 	TokensEarned int64         `json:"tokens_earned"`
 	Balance      int64         `json:"balance"`
 }
+
+type NodeList struct {
+	Nodes []map[string]Node `json:"Nodes"`
+}
+
+type Node struct {
+	ID                string      `json:"id"`
+	N2NHost           string      `json:"n2n_host"`
+	Host              string      `json:"host"`
+	Port              int         `json:"port"`
+	PublicKey         string      `json:"public_key"`
+	ShortName         string      `json:"short_name"`
+	BuildTag          string      `json:"build_tag"`
+	TotalStake        int64       `json:"total_stake"`
+	DelegateWallet    string      `json:"delegate_wallet"`
+	ServiceCharge     float64     `json:"service_charge"`
+	NumberOfDelegates int         `json:"number_of_delegates"`
+	MinStake          int64       `json:"min_stake"`
+	MaxStake          int64       `json:"max_stake"`
+	Stat              interface{} `json:"stat"`
+}
+
+type Sharder struct {
+	ID           string `json:"id"`
+	Version      string `json:"version"`
+	CreationDate int64  `json:"creation_date"`
+	PublicKey    string `json:"public_key"`
+	N2NHost      string `json:"n2n_host"`
+	Host         string `json:"host"`
+	Port         int    `json:"port"`
+	Path         string `json:"path"`
+	Type         int    `json:"type"`
+	Description  string `json:"description"`
+	SetIndex     int    `json:"set_index"`
+	Status       int    `json:"status"`
+	Info         struct {
+		BuildTag                string `json:"build_tag"`
+		StateMissingNodes       int    `json:"state_missing_nodes"`
+		MinersMedianNetworkTime int64  `json:"miners_median_network_time"`
+		AvgBlockTxns            int    `json:"avg_block_txns"`
+	} `json:"info"`
+}

--- a/internal/cli/util/utils.go
+++ b/internal/cli/util/utils.go
@@ -28,6 +28,21 @@ func RunCommand(commandString string) ([]string, error) {
 	return sanitizeOutput(rawOutput), err
 }
 
+func RunCommandWithRawOutput(commandString string) ([]string, error) {
+	command := parseCommand(commandString)
+	commandName := command[0]
+	args := command[1:]
+
+	sanitizedArgs := sanitizeArgs(args)
+	rawOutput, err := executeCommand(commandName, sanitizedArgs)
+
+	Logger.Debugf("Command [%v] exited with error [%v] and output [%v]", commandString, err, string(rawOutput))
+
+	output := strings.Split(string(rawOutput), "\n")
+
+	return output, err
+}
+
 func RunCommandWithRetry(t *testing.T, commandString string, maxAttempts int, backoff time.Duration) ([]string, error) {
 	red := "\033[31m"
 	yellow := "\033[33m"

--- a/tests/cli_tests/block_rewards_test.go
+++ b/tests/cli_tests/block_rewards_test.go
@@ -1,0 +1,378 @@
+package cli_tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	apimodel "github.com/0chain/system_test/internal/api/model"
+	climodel "github.com/0chain/system_test/internal/cli/model"
+	cliutil "github.com/0chain/system_test/internal/cli/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	blockRewardConfigKey       = "block_reward"
+	epochConfigKey             = "epoch"
+	rewardDeclineRateConfigKey = "reward_decline_rate"
+	rewardRateConfigKey        = "reward_rate"
+	shareRatioConfigKey        = "share_ratio"
+)
+
+func TestBlockRewards(t *testing.T) { // nolint:gocyclo // team preference is to have codes all within test.
+	t.Parallel()
+
+	t.Run("Miner rewards", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
+
+		output, err = executeFaucetWithTokens(t, configPath, 1)
+		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
+
+		// Get MinerSC Global Config
+		output, err = getMinerSCConfig(t, configPath)
+		require.Nil(t, err, "get miners sc config failed", strings.Join(output, "\n"))
+		require.Greater(t, len(output), 0)
+
+		mconfig := map[string]float64{}
+		for _, o := range output {
+			configPair := strings.Split(o, "\t")
+			val, err := strconv.ParseFloat(strings.TrimSpace(configPair[1]), 64)
+			require.Nil(t, err, "config val %s for %s is unexpected not float64: %s", configPair[1], configPair[0], strings.Join(output, "\n"))
+			mconfig[strings.TrimSpace(configPair[0])] = val
+		}
+
+		// Get miner list.
+		output, err = getMiners(t, configPath)
+		require.Nil(t, err, "get miners failed", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var miners climodel.NodeList
+		err = json.Unmarshal([]byte(output[0]), &miners)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", output[0], err)
+		require.NotEmpty(t, miners.Nodes, "No miners found: %v", strings.Join(output, "\n"))
+
+		// Use first miner
+		var miner climodel.Node
+		for _, m := range miners.Nodes[0] {
+			miner = m
+			break
+		}
+
+		// Get sharder list.
+		output, err = getSharders(t, configPath)
+		require.Nil(t, err, "get sharders failed", strings.Join(output, "\n"))
+		require.Greater(t, len(output), 1)
+		require.Equal(t, "MagicBlock Sharders", output[0])
+
+		var sharders map[string]climodel.Sharder
+		err = json.Unmarshal([]byte(strings.Join(output[1:], "")), &sharders)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output[1:], "\n"), err)
+		require.NotEmpty(t, sharders, "No sharders found: %v", strings.Join(output[1:], "\n"))
+
+		// Use first sharder.
+		var sharder climodel.Sharder
+		for _, s := range sharders {
+			sharder = s
+			break
+		}
+
+		// Get base URL for API calls.
+		sharderBaseUrl := getNodeBaseURL(sharder.Host, sharder.Port)
+
+		// Get the starting balance for miner's delegate wallet.
+		res, err := apiGetBalance(sharderBaseUrl, miner.ID)
+		require.Nil(t, err, "Error retrieving miner %s balance", miner.ID)
+		require.True(t, res.StatusCode >= 200 && res.StatusCode < 300, "Failed API request to check miner %s balance: %d", miner.ID, res.StatusCode)
+		require.NotNil(t, res.Body, "Balance API response must not be nil")
+
+		bt, err := ioutil.ReadAll(res.Body)
+		require.Nil(t, err, "Error reading response body")
+
+		var startBalance apimodel.Balance
+		err = json.Unmarshal(bt, &startBalance)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", string(bt), err)
+
+		// Do 5 lock transactions with fees
+		for i := 0; i < 5; i++ {
+			output, err = lockInterest(t, configPath, true, 1, false, 0, true, 0.1, 0.1)
+			require.Nil(t, err, "lock interest failed", strings.Join(output, "\n"))
+			require.Len(t, output, 1)
+			require.Equal(t, "Tokens (0.100000) locked successfully", output[0])
+		}
+
+		// Get the ending balance for miner's delegate wallet.
+		res, err = apiGetBalance(sharderBaseUrl, miner.ID)
+		require.Nil(t, err, "Error retrieving miner %s balance", miner.ID)
+		require.True(t, res.StatusCode >= 200 && res.StatusCode < 300, "Failed API request to check miner %s balance: %d", miner.ID, res.StatusCode)
+		require.NotNil(t, res.Body, "Balance API response must not be nil")
+
+		bt, err = ioutil.ReadAll(res.Body)
+		require.Nil(t, err, "Error reading response body")
+
+		var endBalance apimodel.Balance
+		err = json.Unmarshal(bt, &endBalance)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", string(bt), err)
+
+		totalRewardsAndFees := int64(0)
+		// Calculate the total rewards and fees for this miner.
+		for round := startBalance.Round + 1; round <= endBalance.Round; round++ {
+			// Get round details
+			res, err := apiGetBlock(sharderBaseUrl, round)
+			require.Nil(t, err, "Error retrieving block %d", round)
+			require.True(t, res.StatusCode >= 200 && res.StatusCode < 300, "Failed API request to get block %d details: %d", round, res.StatusCode)
+			require.NotNil(t, res.Body, "Balance API response must not be nil")
+
+			bt, err = ioutil.ReadAll(res.Body)
+			require.Nil(t, err, "Error reading response body: %v", err)
+
+			var block apimodel.Block
+			err = json.Unmarshal(bt, &block)
+			require.Nil(t, err, "Error deserializing JSON string `%s`: %v", string(bt), err)
+
+			// No expected rewards for this miner if not the generator of block.
+			if block.Block.MinerId != miner.ID {
+				continue
+			}
+
+			// Get total block fees
+			blockFees := int64(0)
+			for _, txn := range block.Block.Transactions {
+				blockFees += txn.TransactionFee
+			}
+
+			rewardRate := mconfig[rewardRateConfigKey]
+
+			epochs := round / int64(mconfig[epochConfigKey])
+			for i := int64(0); i < epochs; i++ {
+				// new reward ratio = current reward rate * (1.0 - reward decline rate)
+				rewardRate *= 1.0 - mconfig[rewardDeclineRateConfigKey]
+			}
+
+			// block reward (mint) = block reward (configured) * reward rate
+			blockRewardMint := mconfig[blockRewardConfigKey] * 1e10 * rewardRate
+
+			// generator rewards = block reward * share ratio
+			generatorRewards := blockRewardMint * mconfig[shareRatioConfigKey]
+
+			// generator reward service charge = generator rewards * service charge
+			generatorRewardServiceCharge := generatorRewards * miner.ServiceCharge
+			generatorRewardsRemaining := generatorRewards - generatorRewardServiceCharge
+
+			// generator fees = block fees * share ratio
+			generatorFees := float64(blockFees) * mconfig[shareRatioConfigKey]
+
+			// generator fee service charge = generator fees * service charge
+			generatorFeeServiceCharge := generatorFees * miner.ServiceCharge
+			generatorFeeRemaining := generatorFees - generatorFeeServiceCharge
+
+			totalRewardsAndFees += int64(generatorRewardServiceCharge)
+			totalRewardsAndFees += int64(generatorFeeServiceCharge)
+
+			// if none staked at node, node gets all rewards
+			if miner.TotalStake == 0 {
+				totalRewardsAndFees += int64(generatorRewardsRemaining)
+				totalRewardsAndFees += int64(generatorFeeRemaining)
+			}
+		}
+
+		wantBalanceDiff := totalRewardsAndFees
+		gotBalanceDiff := endBalance.Balance - startBalance.Balance
+		acceptableRoundingEpsilon := 100.0
+		assert.InEpsilonf(t, wantBalanceDiff, gotBalanceDiff, acceptableRoundingEpsilon, "expected total rewards and fees not matching: want %d, got %d", wantBalanceDiff, gotBalanceDiff)
+	})
+
+	t.Run("Sharder rewards", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
+
+		output, err = executeFaucetWithTokens(t, configPath, 1)
+		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
+
+		// Get MinerSC Global Config
+		output, err = getMinerSCConfig(t, configPath)
+		require.Nil(t, err, "get miners sc config failed", strings.Join(output, "\n"))
+		require.Greater(t, len(output), 0)
+
+		mconfig := map[string]float64{}
+		for _, o := range output {
+			configPair := strings.Split(o, "\t")
+			val, err := strconv.ParseFloat(strings.TrimSpace(configPair[1]), 64)
+			require.Nil(t, err, "config val %s for %s is unexpected not float64: %s", configPair[1], configPair[0], strings.Join(output, "\n"))
+			mconfig[strings.TrimSpace(configPair[0])] = val
+		}
+
+		// Get sharder list.
+		output, err = getSharders(t, configPath)
+		require.Nil(t, err, "get sharders failed", strings.Join(output, "\n"))
+		require.Greater(t, len(output), 1)
+		require.Equal(t, "MagicBlock Sharders", output[0])
+
+		var sharders map[string]climodel.Sharder
+		err = json.Unmarshal([]byte(strings.Join(output[1:], "")), &sharders)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output[1:], "\n"), err)
+		require.NotEmpty(t, sharders, "No sharders found: %v", strings.Join(output[1:], "\n"))
+
+		// Use first sharder.
+		var selectedSharder climodel.Sharder
+		for _, s := range sharders {
+			selectedSharder = s
+			break
+		}
+
+		output, err = getNode(t, configPath, selectedSharder.ID)
+		require.Nil(t, err, "get node %s failed", selectedSharder.ID, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var nodeRes map[string]climodel.Node
+		err = json.Unmarshal([]byte(strings.Join(output, "")), &nodeRes)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.NotEmpty(t, nodeRes, "No node found: %v", strings.Join(output, "\n"))
+
+		var sharder climodel.Node
+		for _, n := range nodeRes {
+			sharder = n
+			break
+		}
+
+		// Get base URL for API calls.
+		sharderBaseUrl := getNodeBaseURL(sharder.Host, sharder.Port)
+
+		// Get the starting balance for sharder's delegate wallet.
+		res, err := apiGetBalance(sharderBaseUrl, sharder.ID)
+		require.Nil(t, err, "Error retrieving sharder %s balance", sharder.ID)
+		require.True(t, res.StatusCode >= 200 && res.StatusCode < 300, "Failed API request to check sharder %s balance: %d", sharder.ID, res.StatusCode)
+		require.NotNil(t, res.Body, "Balance API response must not be nil")
+
+		bt, err := ioutil.ReadAll(res.Body)
+		require.Nil(t, err, "Error reading response body")
+
+		var startBalance apimodel.Balance
+		err = json.Unmarshal(bt, &startBalance)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", string(bt), err)
+
+		// Do 5 lock transactions with fees
+		for i := 0; i < 5; i++ {
+			output, err = lockInterest(t, configPath, true, 1, false, 0, true, 0.1, 0.1)
+			require.Nil(t, err, "lock interest failed", strings.Join(output, "\n"))
+			require.Len(t, output, 1)
+			require.Equal(t, "Tokens (0.100000) locked successfully", output[0])
+		}
+
+		// Get the ending balance for sharder's delegate wallet.
+		res, err = apiGetBalance(sharderBaseUrl, sharder.ID)
+		require.Nil(t, err, "Error retrieving sharder %s balance", sharder.ID)
+		require.True(t, res.StatusCode >= 200 && res.StatusCode < 300, "Failed API request to check sharder %s balance: %d", sharder.ID, res.StatusCode)
+		require.NotNil(t, res.Body, "Balance API response must not be nil")
+
+		bt, err = ioutil.ReadAll(res.Body)
+		require.Nil(t, err, "Error reading response body")
+
+		var endBalance apimodel.Balance
+		err = json.Unmarshal(bt, &endBalance)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", string(bt), err)
+
+		totalRewardsAndFees := int64(0)
+		// Calculate the total rewards and fees for this sharder.
+		for round := startBalance.Round + 1; round <= endBalance.Round; round++ {
+			// Get round details
+			res, err := apiGetBlock(sharderBaseUrl, round)
+			require.Nil(t, err, "Error retrieving block %d", round)
+			require.True(t, res.StatusCode >= 200 && res.StatusCode < 300, "Failed API request to get block %d details: %d", round, res.StatusCode)
+			require.NotNil(t, res.Body, "Balance API response must not be nil")
+
+			bt, err = ioutil.ReadAll(res.Body)
+			require.Nil(t, err, "Error reading response body: %v", err)
+
+			var block apimodel.Block
+			err = json.Unmarshal(bt, &block)
+			require.Nil(t, err, "Error deserializing JSON string `%s`: %v", string(bt), err)
+
+			// Get total block fees
+			blockFees := int64(0)
+			for _, txn := range block.Block.Transactions {
+				blockFees += txn.TransactionFee
+			}
+
+			rewardRate := mconfig[rewardRateConfigKey]
+
+			epochs := round / int64(mconfig[epochConfigKey])
+			for i := int64(0); i < epochs; i++ {
+				// new reward rate = current reward rate * (1.0 - reward decline rate)
+				rewardRate *= 1.0 - mconfig[rewardDeclineRateConfigKey]
+			}
+
+			// block reward (mint) = block reward (configured) * reward rate
+			blockRewardMint := mconfig[blockRewardConfigKey] * 1e10 * rewardRate
+
+			// generator rewards = block reward * share ratio
+			// sharders rewards  = block reward - generator rewards
+			sharderRewards := blockRewardMint * (1 - mconfig[shareRatioConfigKey])
+			sharderRewardsShare := sharderRewards / float64(len(sharders))
+
+			// sharder reward service charge = sharders rewards * service charge
+			sharderRewardServiceCharge := sharderRewardsShare * sharder.ServiceCharge
+			sharderRewardsRemaining := sharderRewardsShare - sharderRewardServiceCharge
+
+			// generator fees = block fees * share ratio
+			// sharders fees  = block fees - generator fees
+			sharderFees := float64(blockFees) * (1 - mconfig[shareRatioConfigKey])
+			sharderFeesShare := sharderFees / float64(len(sharders))
+
+			// sharder fee service charge = sharders fees * service charge
+			sharderFeeServiceCharge := sharderFeesShare * sharder.ServiceCharge
+			sharderFeeRemaining := sharderFeesShare - sharderFeeServiceCharge
+
+			totalRewardsAndFees += int64(sharderRewardServiceCharge)
+			totalRewardsAndFees += int64(sharderFeeServiceCharge)
+
+			// if none staked at node, node gets all rewards
+			if sharder.TotalStake == 0 {
+				totalRewardsAndFees += int64(sharderRewardsRemaining)
+				totalRewardsAndFees += int64(sharderFeeRemaining)
+			}
+		}
+
+		wantBalanceDiff := totalRewardsAndFees
+		gotBalanceDiff := endBalance.Balance - startBalance.Balance
+		acceptableRoundingEpsilon := 100.0
+		assert.InEpsilonf(t, wantBalanceDiff, gotBalanceDiff, acceptableRoundingEpsilon, "expected total rewards and fees not matching: want %d, got %d", wantBalanceDiff, gotBalanceDiff)
+	})
+}
+
+func getNode(t *testing.T, cliConfigFilename, nodeID string) ([]string, error) {
+	return cliutil.RunCommand("./zwallet mn-info --silent --id " + nodeID + " --wallet " + escapedTestName(t) + "_wallet.json --configDir ./config --config " + cliConfigFilename)
+}
+
+func getMiners(t *testing.T, cliConfigFilename string) ([]string, error) {
+	return cliutil.RunCommand("./zwallet ls-miners --json --silent --wallet " + escapedTestName(t) + "_wallet.json --configDir ./config --config " + cliConfigFilename)
+}
+
+func getMinerSCConfig(t *testing.T, cliConfigFilename string) ([]string, error) {
+	return cliutil.RunCommand("./zwallet mn-config --silent --wallet " + escapedTestName(t) + "_wallet.json --configDir ./config --config " + cliConfigFilename)
+}
+
+func getSharders(t *testing.T, cliConfigFilename string) ([]string, error) {
+	return cliutil.RunCommandWithRawOutput("./zwallet ls-sharders --json --silent --wallet " + escapedTestName(t) + "_wallet.json --configDir ./config --config " + cliConfigFilename)
+}
+
+func getNodeBaseURL(host string, port int) string {
+	return fmt.Sprintf(`http://%s:%d`, host, port)
+}
+
+func apiGetBalance(sharderBaseURL, clientID string) (*http.Response, error) {
+	return http.Get(sharderBaseURL + "/v1/client/get/balance?client_id=" + clientID)
+}
+
+func apiGetBlock(sharderBaseURL string, round int64) (*http.Response, error) {
+	return http.Get(fmt.Sprintf(sharderBaseURL+"/v1/block/get?content=full&round=%d", round))
+}

--- a/tests/cli_tests/zwalletcli_lock_unlock_interest_test.go
+++ b/tests/cli_tests/zwalletcli_lock_unlock_interest_test.go
@@ -44,7 +44,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		require.Regexp(t, regexp.MustCompile(`Balance: 1.000 ZCN \(\d*\.?\d+ USD\)$`), output[0])
 
 		// lock tokens
-		output, err = lockInterest(t, configPath, true, 1, false, 0, true, 1)
+		output, err = lockInterest(t, configPath, true, 1, false, 0, true, 1, 0)
 		require.Nil(t, err, "lock interest failed", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Tokens (1.000000) locked successfully", output[0])
@@ -160,7 +160,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		require.Regexp(t, regexp.MustCompile(`Balance: 800.000 mZCN \(\d*\.?\d+ USD\)$`), output[0])
 
 		// first lock of 0.8 token for 100 min
-		output, err = lockInterest(t, configPath, true, 100, false, 0, true, 0.8)
+		output, err = lockInterest(t, configPath, true, 100, false, 0, true, 0.8, 0)
 		require.Nil(t, err, "lock interest failed", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Tokens (0.800000) locked successfully", output[0])
@@ -189,7 +189,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		require.Regexp(t, regexp.MustCompile(`Balance: `+balancePrint(wantInterestEarnedFromLock1+int64(tokensToLock2*1e10))+` \(\d*\.?\d+ USD\)$`), output[0])
 
 		// second lock 0.5 token for 5 hrs
-		output, err = lockInterest(t, configPath, false, 0, true, 5, true, 0.5)
+		output, err = lockInterest(t, configPath, false, 0, true, 5, true, 0.5, 0)
 		require.Nil(t, err, "lock interest failed", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Tokens (0.500000) locked successfully", output[0])
@@ -265,7 +265,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		require.Regexp(t, regexp.MustCompile(`Balance: 951.123 mZCN \(\d*\.?\d+ USD\)$`), output[0])
 
 		// lock 0.951123 token for 200 minutes
-		output, err = lockInterest(t, configPath, true, int64(lockDuration.Minutes()), false, 0, true, 0.951123)
+		output, err = lockInterest(t, configPath, true, int64(lockDuration.Minutes()), false, 0, true, 0.951123, 0)
 		require.Nil(t, err, "lock interest failed", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Tokens (0.951123) locked successfully", output[0])
@@ -321,7 +321,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		require.Regexp(t, regexp.MustCompile(`Balance: 750.000 mZCN \(\d*\.?\d+ USD\)$`), output[0])
 
 		// lock 0.75 token for 24 hours
-		output, err = lockInterest(t, configPath, false, 0, true, int64(lockDuration.Hours()), true, 0.75)
+		output, err = lockInterest(t, configPath, false, 0, true, int64(lockDuration.Hours()), true, 0.75, 0)
 		require.Nil(t, err, "lock interest failed", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Tokens (0.750000) locked successfully", output[0])
@@ -379,7 +379,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		require.Regexp(t, regexp.MustCompile(`Balance: 250.000 mZCN \(\d*\.?\d+ USD\)$`), output[0])
 
 		// lock
-		output, err = lockInterest(t, configPath, true, int64(lockDurationMin.Minutes()), true, int64(lockDurationHr.Hours()), true, tokensToLock)
+		output, err = lockInterest(t, configPath, true, int64(lockDurationMin.Minutes()), true, int64(lockDurationHr.Hours()), true, tokensToLock, 0)
 		require.Nil(t, err, "lock interest failed", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Tokens (0.250000) locked successfully", output[0])
@@ -435,7 +435,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		require.Regexp(t, regexp.MustCompile(`Balance: 100.000 mZCN \(\d*\.?\d+ USD\)$`), output[0])
 
 		// lock
-		output, err = lockInterest(t, configPath, false, 0, true, int64(lockDuration.Hours()), true, tokensToLock)
+		output, err = lockInterest(t, configPath, false, 0, true, int64(lockDuration.Hours()), true, tokensToLock, 0)
 		require.Nil(t, err, "lock interest failed", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		// FIXME precision is lost - should say  `Tokens (0.000000001) locked successfully`
@@ -479,7 +479,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		output, err = executeFaucetWithTokens(t, configPath, 1)
 		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
 
-		output, err = lockInterest(t, configPath, true, 5, false, 0, true, 1.1)
+		output, err = lockInterest(t, configPath, true, 5, false, 0, true, 1.1, 0)
 		require.NotNil(t, err, "Missing expected lock interest failure", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, `Failed to lock tokens. {"error": "verify transaction failed"}`, output[0])
@@ -494,7 +494,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		output, err = executeFaucetWithTokens(t, configPath, 1)
 		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
 
-		output, err = lockInterest(t, configPath, false, 0, false, 0, true, 1)
+		output, err = lockInterest(t, configPath, false, 0, false, 0, true, 1, 0)
 		require.NotNil(t, err, "Missing expected lock interest failure", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Error: durationHr and durationMin flag is missing. atleast one is required", output[0])
@@ -509,7 +509,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		output, err = executeFaucetWithTokens(t, configPath, 1)
 		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
 
-		output, err = lockInterest(t, configPath, true, 0, false, 0, true, 1)
+		output, err = lockInterest(t, configPath, true, 0, false, 0, true, 1, 0)
 		require.NotNil(t, err, "Missing expected lock interest failure", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Error: invalid duration", output[0])
@@ -524,7 +524,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		output, err = executeFaucetWithTokens(t, configPath, 1)
 		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
 
-		output, err = lockInterest(t, configPath, false, 0, true, 0, true, 1)
+		output, err = lockInterest(t, configPath, false, 0, true, 0, true, 1, 0)
 		require.NotNil(t, err, "Missing expected lock interest failure", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Error: invalid duration", output[0])
@@ -541,7 +541,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 
 		over1YearMins := int64(year.Minutes()) + 1
 
-		output, err = lockInterest(t, configPath, true, int64(over1YearMins), false, 0, true, 1)
+		output, err = lockInterest(t, configPath, true, int64(over1YearMins), false, 0, true, 1, 0)
 		require.NotNil(t, err, "Missing expected lock interest failure", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, `Failed to lock tokens. {"error": "verify transaction failed"}`, output[0])
@@ -558,7 +558,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 
 		over1YearHrs := int64(year.Hours()) + 1
 
-		output, err = lockInterest(t, configPath, false, 0, true, int64(over1YearHrs), true, 1)
+		output, err = lockInterest(t, configPath, false, 0, true, int64(over1YearHrs), true, 1, 0)
 		require.NotNil(t, err, "Missing expected lock interest failure", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, `Failed to lock tokens. {"error": "verify transaction failed"}`, output[0])
@@ -573,7 +573,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		output, err = executeFaucetWithTokens(t, configPath, 1)
 		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
 
-		output, err = lockInterest(t, configPath, true, 0, true, 0, true, 1)
+		output, err = lockInterest(t, configPath, true, 0, true, 0, true, 1, 0)
 		require.NotNil(t, err, "Missing expected lock interest failure", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Error: invalid duration", output[0])
@@ -588,7 +588,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		output, err = executeFaucetWithTokens(t, configPath, 1)
 		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
 
-		output, err = lockInterest(t, configPath, true, 10, false, 0, false, 0)
+		output, err = lockInterest(t, configPath, true, 10, false, 0, false, 0, 0)
 		require.NotNil(t, err, "Missing expected lock interest failure", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Error: tokens flag is missing", output[0])
@@ -603,7 +603,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		output, err = executeFaucetWithTokens(t, configPath, 1)
 		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
 
-		output, err = lockInterest(t, configPath, true, 10, false, 0, true, 0)
+		output, err = lockInterest(t, configPath, true, 10, false, 0, true, 0, 0)
 		require.NotNil(t, err, "Missing expected lock interest failure", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, `Failed to lock tokens. {"error": "verify transaction failed"}`, output[0])
@@ -618,7 +618,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		output, err = executeFaucetWithTokens(t, configPath, 1)
 		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
 
-		output, err = lockInterest(t, configPath, true, 10, false, 0, true, 0.000_000_000_9)
+		output, err = lockInterest(t, configPath, true, 10, false, 0, true, 0.000_000_000_9, 0)
 		require.NotNil(t, err, "Missing expected lock interest failure", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, `Failed to lock tokens. {"error": "verify transaction failed"}`, output[0])
@@ -633,7 +633,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		output, err = executeFaucetWithTokens(t, configPath, 1)
 		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
 
-		output, err = lockInterest(t, configPath, true, 10, false, 0, true, -1)
+		output, err = lockInterest(t, configPath, true, 10, false, 0, true, -1, 0)
 		require.NotNil(t, err, "Missing expected lock interest failure", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, `Failed to lock tokens. submit transaction failed. {"code":"invalid_request","error":"invalid_request: Invalid request (value must be greater than or equal to zero)"}`, output[0])
@@ -648,7 +648,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		output, err = executeFaucetWithTokens(t, configPath, 1)
 		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
 
-		output, err = lockInterest(t, configPath, true, 10, false, 0, true, 1.01)
+		output, err = lockInterest(t, configPath, true, 10, false, 0, true, 1.01, 0)
 		require.NotNil(t, err, "Missing expected lock interest failure", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, `Failed to lock tokens. {"error": "verify transaction failed"}`, output[0])
@@ -714,7 +714,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		require.Regexp(t, regexp.MustCompile(`Balance: 1.000 ZCN \(\d*\.?\d+ USD\)$`), output[0])
 
 		// lock 1 token for 1 min
-		output, err = lockInterest(t, configPath, true, 1, false, 0, true, 1)
+		output, err = lockInterest(t, configPath, true, 1, false, 0, true, 1, 0)
 		require.Nil(t, err, "lock interest failed", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Tokens (1.000000) locked successfully", output[0])
@@ -769,7 +769,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 		require.Regexp(t, regexp.MustCompile(`Balance: 1.000 ZCN \(\d*\.?\d+ USD\)$`), output[0])
 
 		// lock 1 token for 1 min
-		output, err = lockInterest(t, configPath, true, 1, false, 0, true, 1)
+		output, err = lockInterest(t, configPath, true, 1, false, 0, true, 1, 0)
 		require.Nil(t, err, "lock interest failed", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "Tokens (1.000000) locked successfully", output[0])
@@ -821,7 +821,7 @@ func TestLockAndUnlockInterest(t *testing.T) {
 }
 
 func lockInterest(t *testing.T, cliConfigFilename string, withDurationMin bool, durationMin int64,
-	withDurationHr bool, durationHr int64, withTokens bool, tokens float64) ([]string, error) {
+	withDurationHr bool, durationHr int64, withTokens bool, tokens float64, fee float64) ([]string, error) {
 	cmd := "./zwallet lock --silent --wallet " + escapedTestName(t) + "_wallet.json --configDir ./config --config " + cliConfigFilename
 	if withDurationMin {
 		cmd += ` --durationMin "` + strconv.FormatInt(durationMin, 10) + `"`
@@ -831,6 +831,9 @@ func lockInterest(t *testing.T, cliConfigFilename string, withDurationMin bool, 
 	}
 	if withTokens {
 		cmd += ` --tokens "` + strconv.FormatFloat(tokens, 'f', 10, 64) + `"`
+	}
+	if fee > 0 {
+		cmd += ` --fee ` + strconv.FormatFloat(tokens, 'f', 10, 64)
 	}
 	return cliutil.RunCommand(cmd)
 }


### PR DESCRIPTION
Resolves https://github.com/0chain/system_test/issues/41

Scenarios
- Miner rewards 
- Sharder rewards

No tests involve staking yet.

Logic for the tests are basically same.
- Get starting and ending balances of node (service provider) on time X and X+Y 
- Do some transactions in between to generate block fees
- For all rounds covered, calculate the block fees and block rewards and the expected share of the node (service provider)
- Assert the balance differences matches the calculated amount

The tests requires doing API calls for getting block/round details and getting node balances with round number associated.