### PR TITLE
Modify existing file (copy, rename, move, update file attributes) system tests

### DIFF
--- a/tests/cli_tests/test.json
+++ b/tests/cli_tests/test.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "8bd24a1b39c56b76b37f68650edc1ce75a6642253a08b68d7539c94001019346",
+    "balance": 10000000000,
+    "expire_at": 1635344623,
+    "allocation_id": "8bd24a1b39c56b76b37f68650edc1ce75a6642253a08b68d7539c94001019346",
+    "blobbers": [
+      {
+        "blobber_id": "12b820dea88831a1d2711f2705e2b239d01b58a030c36c5facea1c32600271dd",
+        "balance": 2500000000
+      },
+      {
+        "blobber_id": "58ef59871279dc710a86ff75999d99426c6a0606340fde3e0145dc6e067c64fb",
+        "balance": 2500000000
+      },
+      {
+        "blobber_id": "5d2cc1ecafc9f828b5da8bed28fe3f15a786cc5429b9fd85adb0815ba13e2c8f",
+        "balance": 2500000000
+      },
+      {
+        "blobber_id": "a91ea8d3b7f50e8d6e2b5e96aee1ee4d6e7042757593d976cb481f586cffd526",
+        "balance": 2500000000
+      }
+    ],
+    "locked": true
+  }
+]
+{
+  "id": "6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7:challengepool:8bd24a1b39c56b76b37f68650edc1ce75a6642253a08b68d7539c94001019346",
+  "balance": 0,
+  "start_time": 1635340903,
+  "expiration": 1635344623,
+  "finalized": false
+}
+[
+  {
+    "id": "8bd24a1b39c56b76b37f68650edc1ce75a6642253a08b68d7539c94001019346",
+    "balance": 10000000000,
+    "expire_at": 1635344623,
+    "allocation_id": "8bd24a1b39c56b76b37f68650edc1ce75a6642253a08b68d7539c94001019346",
+    "blobbers": [
+      {
+        "blobber_id": "12b820dea88831a1d2711f2705e2b239d01b58a030c36c5facea1c32600271dd",
+        "balance": 2500000000
+      },
+      {
+        "blobber_id": "58ef59871279dc710a86ff75999d99426c6a0606340fde3e0145dc6e067c64fb",
+        "balance": 2500000000
+      },
+      {
+        "blobber_id": "5d2cc1ecafc9f828b5da8bed28fe3f15a786cc5429b9fd85adb0815ba13e2c8f",
+        "balance": 2500000000
+      },
+      {
+        "blobber_id": "a91ea8d3b7f50e8d6e2b5e96aee1ee4d6e7042757593d976cb481f586cffd526",
+        "balance": 2500000000
+      }
+    ],
+    "locked": true
+  }
+]
+{
+  "id": "6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7:challengepool:8bd24a1b39c56b76b37f68650edc1ce75a6642253a08b68d7539c94001019346",
+  "balance": 0,
+  "start_time": 1635340903,
+  "expiration": 1635344623,
+  "finalized": false
+}

--- a/tests/cli_tests/zboxcli_download_test.go
+++ b/tests/cli_tests/zboxcli_download_test.go
@@ -758,7 +758,7 @@ func TestDownload(t *testing.T) {
 
 		expected := fmt.Sprintf(
 			"Download failed. Local file already exists '%s'",
-			os.TempDir()+filepath.Base(filename),
+			filepath.Dir(os.TempDir())+"/"+filepath.Base(filename),
 		)
 		require.Equal(t, expected, output[0])
 	})

--- a/tests/cli_tests/zboxcli_download_test.go
+++ b/tests/cli_tests/zboxcli_download_test.go
@@ -751,14 +751,14 @@ func TestDownload(t *testing.T) {
 		output, err := downloadFile(t, configPath, createParams(map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotepath + filepath.Base(filename),
-			"localpath":  "tmp/",
+			"localpath":  os.TempDir(),
 		}))
 		require.NotNil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 
 		expected := fmt.Sprintf(
 			"Download failed. Local file already exists '%s'",
-			"tmp/"+filepath.Base(filename),
+			os.TempDir()+filepath.Base(filename),
 		)
 		require.Equal(t, expected, output[0])
 	})

--- a/tests/cli_tests/zboxcli_download_test.go
+++ b/tests/cli_tests/zboxcli_download_test.go
@@ -758,7 +758,7 @@ func TestDownload(t *testing.T) {
 
 		expected := fmt.Sprintf(
 			"Download failed. Local file already exists '%s'",
-			filepath.Dir(os.TempDir())+"/"+filepath.Base(filename),
+			strings.TrimSuffix(os.TempDir(), "/")+"/"+filepath.Base(filename),
 		)
 		require.Equal(t, expected, output[0])
 	})

--- a/tests/cli_tests/zboxcli_file_copy_test.go
+++ b/tests/cli_tests/zboxcli_file_copy_test.go
@@ -511,38 +511,13 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 	t.Run("copy file with no allocation param should fail", func(t *testing.T) {
 		t.Parallel()
 
-		allocSize := int64(2048)
-		fileSize := int64(256)
-
-		file := generateRandomTestFileName(t)
-		err := createFileWithSize(file, fileSize)
-		require.Nil(t, err)
-
-		filename := filepath.Base(file)
-		remotePath := "/child/" + filename
-		destpath := "/"
-
-		allocationID := setupAllocation(t, configPath, map[string]interface{}{
-			"size": allocSize,
-		})
-
-		output, err := uploadFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
-			"localpath":  file,
-		})
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2)
-
-		expected := fmt.Sprintf(
-			"Status completed callback. Type = application/octet-stream. Name = %s",
-			filepath.Base(file),
-		)
-		require.Equal(t, expected, output[1])
+		// unused wallet, just added to avoid having the creating new wallet outputs on copy
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
 		output, err = copyFile(t, configPath, map[string]interface{}{
-			"remotepath": remotePath,
-			"destpath":   destpath,
+			"remotepath": "/abc.txt",
+			"destpath":   "/",
 		})
 		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox copy should throw non-zero code
 		require.Len(t, output, 1)
@@ -552,38 +527,13 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 	t.Run("copy file with no remotepath param should fail", func(t *testing.T) {
 		t.Parallel()
 
-		allocSize := int64(2048)
-		fileSize := int64(256)
-
-		file := generateRandomTestFileName(t)
-		err := createFileWithSize(file, fileSize)
-		require.Nil(t, err)
-
-		filename := filepath.Base(file)
-		remotePath := "/child/" + filename
-		destpath := "/"
-
-		allocationID := setupAllocation(t, configPath, map[string]interface{}{
-			"size": allocSize,
-		})
-
-		output, err := uploadFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
-			"localpath":  file,
-		})
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2)
-
-		expected := fmt.Sprintf(
-			"Status completed callback. Type = application/octet-stream. Name = %s",
-			filepath.Base(file),
-		)
-		require.Equal(t, expected, output[1])
+		// unused wallet, just added to avoid having the creating new wallet outputs on copy
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
 		output, err = copyFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"destpath":   destpath,
+			"allocation": "abcdef",
+			"destpath":   "/",
 		})
 		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox copy should throw non-zero code
 		require.Len(t, output, 1)
@@ -593,37 +543,13 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 	t.Run("copy file with no destpath param should fail", func(t *testing.T) {
 		t.Parallel()
 
-		allocSize := int64(2048)
-		fileSize := int64(256)
-
-		file := generateRandomTestFileName(t)
-		err := createFileWithSize(file, fileSize)
-		require.Nil(t, err)
-
-		filename := filepath.Base(file)
-		remotePath := "/child/" + filename
-
-		allocationID := setupAllocation(t, configPath, map[string]interface{}{
-			"size": allocSize,
-		})
-
-		output, err := uploadFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
-			"localpath":  file,
-		})
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2)
-
-		expected := fmt.Sprintf(
-			"Status completed callback. Type = application/octet-stream. Name = %s",
-			filepath.Base(file),
-		)
-		require.Equal(t, expected, output[1])
+		// unused wallet, just added to avoid having the creating new wallet outputs on copy
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
 		output, err = copyFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
+			"allocation": "abcdef",
+			"remotepath": "/abc.txt",
 		})
 		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox copy should throw non-zero code
 		require.Len(t, output, 1)

--- a/tests/cli_tests/zboxcli_file_copy_test.go
+++ b/tests/cli_tests/zboxcli_file_copy_test.go
@@ -1,7 +1,16 @@
 package cli_tests
 
 import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	climodel "github.com/0chain/system_test/internal/cli/model"
+	cliutils "github.com/0chain/system_test/internal/cli/util"
+	"github.com/stretchr/testify/require"
 )
 
 // copy an object to another folder on blobbers
@@ -18,28 +27,655 @@ import (
 func TestFileCopy(t *testing.T) {
 	t.Parallel()
 
-	t.Run("TODO", func(t *testing.T) {
+	t.Run("copy file to existing directory", func(t *testing.T) {
 		t.Parallel()
 
-		// register wallet
-		// faucet
-		// new alloc
-		// file upload
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destpath := "/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
 		// copy file
+		output, err = copyFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, fmt.Sprintf(remotePath+" copied"), output[0])
+
 		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 3)
+
+		// check if expected file has been copied. both files are there
+		foundAtSource := false
+		foundAtTarget := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				foundAtSource = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+			if f.Path == destpath+filename {
+				foundAtTarget = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.True(t, foundAtSource && foundAtTarget, "both files are not found: ", strings.Join(output, "\n"))
 	})
 
-	// copy to another existing directory
-	// copy to same directory
-	// copy to non-existing directory
-	// copy to directory with existing file with same name
-	// copy with commit
-	// copy to non-existing bad directory
-	// copy non-existing file
-	// copy but no more allocation space
-	// bad allocation
-	// allocation not owned
+	t.Run("copy file to non-existing directory should fail", func(t *testing.T) {
+		t.Parallel()
 
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/" + filename
+		destpath := "/child/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to copy file
+		output, err = copyFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 1)
+
+		// check if file was not copied
+		foundAtSource := false
+		foundAtTarget := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				foundAtSource = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+			if f.Path == destpath+filename {
+				foundAtTarget = true
+			}
+		}
+		require.True(t, foundAtSource, "file at old location is not found: ", strings.Join(output, "\n"))
+		require.False(t, foundAtTarget, "file was unexpectedly copied to new location: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("copy file to same directory should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/" + filename
+		destpath := "/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to copy file
+		output, err = copyFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 1)
+
+		// check if file is still there
+		found := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				found = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.True(t, found, "file not found: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("copy file to another directory with existing file with same name should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		existingFileInDest := generateRandomTestFileName(t)
+		err = createFileWithSize(existingFileInDest, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/" + filename
+		remotePathAtDest := "/target/" + filename
+		destpath := "/target/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// upload file to another directory with same name.
+		output, err = uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePathAtDest,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected = fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to copy file
+		output, err = copyFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 3)
+
+		// check if both existing files are there
+		foundAtSource := false
+		foundAtTarget := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				foundAtSource = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+			if f.Path == remotePathAtDest {
+				foundAtTarget = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.True(t, foundAtSource && foundAtTarget, "both files are not found: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("copy file with commit param", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destpath := "/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// copy file
+		output, err = copyFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destpath":   destpath,
+			"commit":     "",
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 3)
+
+		require.Equal(t, fmt.Sprintf(remotePath+" copied"), output[0])
+
+		match := reCommitResponse.FindStringSubmatch(output[2])
+		require.Len(t, match, 2)
+
+		var commitResp climodel.CommitResponse
+		err = json.Unmarshal([]byte(match[1]), &commitResp)
+		require.Nil(t, err)
+
+		require.Equal(t, "application/octet-stream", commitResp.MetaData.MimeType)
+		require.Equal(t, fileSize, commitResp.MetaData.Size)
+		require.Equal(t, filepath.Base(filename), commitResp.MetaData.Name)
+		require.Equal(t, remotePath, commitResp.MetaData.Path)
+		require.Equal(t, "", commitResp.MetaData.EncryptedKey)
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 3)
+
+		// check if expected file has been copied. both files are there
+		foundAtSource := false
+		foundAtTarget := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				foundAtSource = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+			if f.Path == destpath+filename {
+				foundAtTarget = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.True(t, foundAtSource && foundAtTarget, "both files are not found: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("copy non-existing file should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		// try to copy a file
+		output, err := copyFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": "/child/nonexisting.txt",
+			"destpath":   "/",
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
+	})
+
+	t.Run("copy file from someone else's allocation should fail", func(t *testing.T) {
+		t.Parallel()
+
+		nonAllocOwnerWallet := escapedTestName(t) + "_NON_OWNER"
+
+		output, err := registerWalletForName(configPath, nonAllocOwnerWallet)
+		require.Nil(t, err, "registering wallet failed", err, strings.Join(output, "\n"))
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err = createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destpath := "/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err = uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// copy file
+		output, err = copyFileForWallet(t, configPath, nonAllocOwnerWallet, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 2)
+
+		// check if file was not copied
+		foundAtSource := false
+		foundAtTarget := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				foundAtSource = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+			if f.Path == destpath+filename {
+				foundAtTarget = true
+			}
+		}
+		require.True(t, foundAtSource, "file at old location is not found: ", strings.Join(output, "\n"))
+		require.False(t, foundAtTarget, "file was unexpectedly copied to new location: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("copy file with no allocation param should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destpath := "/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to copy file
+		output, err = copyFile(t, configPath, map[string]interface{}{
+			"remotepath": remotePath,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, "Error: allocation flag is missing", output[0])
+	})
+
+	t.Run("copy file with no remotepath param should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destpath := "/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to copy file
+		output, err = copyFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, "Error: remotepath flag is missing", output[0])
+	})
+
+	t.Run("copy file with no destpath param should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to copy file
+		output, err = copyFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, "Error: destpath flag is missing", output[0])
+	})
+
+	// TODO
 	// curator scenarios?
 	// collaborator scenarios?
+}
+
+func copyFile(t *testing.T, cliConfigFilename string, param map[string]interface{}) ([]string, error) {
+	return copyFileForWallet(t, cliConfigFilename, escapedTestName(t), param)
+}
+
+func copyFileForWallet(t *testing.T, cliConfigFilename, wallet string, param map[string]interface{}) ([]string, error) {
+	t.Logf("Copying file...")
+	p := createParams(param)
+	cmd := fmt.Sprintf(
+		"./zbox copy %s --silent --wallet %s --configDir ./config --config %s",
+		p,
+		wallet+"_wallet.json",
+		cliConfigFilename,
+	)
+
+	// TODO delete
+	fmt.Println(cmd)
+
+	return cliutils.RunCommandWithRetry(t, cmd, 3, time.Second*20)
 }

--- a/tests/cli_tests/zboxcli_file_copy_test.go
+++ b/tests/cli_tests/zboxcli_file_copy_test.go
@@ -27,7 +27,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destpath := "/"
 
@@ -57,7 +56,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		})
 		require.Nil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)
-
 		require.Equal(t, fmt.Sprintf(remotePath+" copied"), output[0])
 
 		// list-all
@@ -104,7 +102,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/" + filename
 		destpath := "/child/"
 
@@ -126,13 +123,12 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to copy file
 		output, err = copyFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
 			"destpath":   destpath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox copy should throw non-zero code
 		require.Len(t, output, 1)
 		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
 
@@ -176,7 +172,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/" + filename
 		destpath := "/"
 
@@ -198,13 +193,12 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to copy file
 		output, err = copyFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
 			"destpath":   destpath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox copy should throw non-zero code
 		require.Len(t, output, 1)
 		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
 
@@ -247,7 +241,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/" + filename
 		destpath := "/target/"
 
@@ -284,13 +277,12 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to copy file
 		output, err = copyFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
 			"destpath":   destpath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox copy should throw non-zero code
 		require.Len(t, output, 1)
 		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
 
@@ -338,7 +330,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destpath := "/"
 
@@ -360,7 +351,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// copy file
 		output, err = copyFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
@@ -369,7 +359,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		})
 		require.Nil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 3)
-
 		require.Equal(t, fmt.Sprintf(remotePath+" copied"), output[0])
 
 		match := reCommitResponse.FindStringSubmatch(output[2])
@@ -433,7 +422,7 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 			"remotepath": "/child/nonexisting.txt",
 			"destpath":   "/",
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox copy should throw non-zero code
 		require.Len(t, output, 1)
 		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
 	})
@@ -454,7 +443,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destpath := "/"
 
@@ -476,13 +464,12 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// copy file
 		output, err = copyFileForWallet(t, configPath, nonAllocOwnerWallet, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
 			"destpath":   destpath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox copy should throw non-zero code
 		require.Len(t, output, 1)
 		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
 
@@ -526,7 +513,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destpath := "/"
 
@@ -548,14 +534,12 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to copy file
 		output, err = copyFile(t, configPath, map[string]interface{}{
 			"remotepath": remotePath,
 			"destpath":   destpath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox copy should throw non-zero code
 		require.Len(t, output, 1)
-
 		require.Equal(t, "Error: allocation flag is missing", output[0])
 	})
 
@@ -570,7 +554,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destpath := "/"
 
@@ -592,14 +575,12 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to copy file
 		output, err = copyFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"destpath":   destpath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox copy should throw non-zero code
 		require.Len(t, output, 1)
-
 		require.Equal(t, "Error: remotepath flag is missing", output[0])
 	})
 
@@ -614,7 +595,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 
 		allocationID := setupAllocation(t, configPath, map[string]interface{}{
@@ -635,14 +615,12 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to copy file
 		output, err = copyFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox copy should throw non-zero code
 		require.Len(t, output, 1)
-
 		require.Equal(t, "Error: destpath flag is missing", output[0])
 	})
 

--- a/tests/cli_tests/zboxcli_file_copy_test.go
+++ b/tests/cli_tests/zboxcli_file_copy_test.go
@@ -374,6 +374,12 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Equal(t, remotePath, commitResp.MetaData.Path)
 		require.Equal(t, "", commitResp.MetaData.EncryptedKey)
 
+		// verify commit txn
+		output, err = verifyTransaction(t, configPath, commitResp.TxnID)
+		require.Nil(t, err, "Could not verify commit transaction", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "Transaction verification success", output[0])
+
 		// list-all
 		output, err = listAll(t, configPath, allocationID)
 		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))

--- a/tests/cli_tests/zboxcli_file_copy_test.go
+++ b/tests/cli_tests/zboxcli_file_copy_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFileCopy(t *testing.T) {
+func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to have codes all within test.
 	t.Parallel()
 
 	t.Run("copy file to existing directory", func(t *testing.T) {
@@ -221,7 +221,7 @@ func TestFileCopy(t *testing.T) {
 		// check if file is still there
 		found := false
 		for _, f := range files {
-			if f.Path == remotePath {
+			if f.Path == remotePath { // nolint:gocritic // this is better than inverted if cond
 				found = true
 				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
 				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))

--- a/tests/cli_tests/zboxcli_file_copy_test.go
+++ b/tests/cli_tests/zboxcli_file_copy_test.go
@@ -623,10 +623,6 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Len(t, output, 1)
 		require.Equal(t, "Error: destpath flag is missing", output[0])
 	})
-
-	// TODO
-	// curator scenarios?
-	// collaborator scenarios?
 }
 
 func copyFile(t *testing.T, cliConfigFilename string, param map[string]interface{}) ([]string, error) {

--- a/tests/cli_tests/zboxcli_file_copy_test.go
+++ b/tests/cli_tests/zboxcli_file_copy_test.go
@@ -1,0 +1,45 @@
+package cli_tests
+
+import (
+	"testing"
+)
+
+// copy an object to another folder on blobbers
+//
+//Usage:
+//  zbox copy [flags]
+//
+//Flags:
+//      --allocation string   Allocation ID
+//      --commit              pass this option to commit the metadata transaction
+//      --destpath string     Destination path for the object. Existing directory the object should be copied to
+//  -h, --help                help for copy
+//      --remotepath string   Remote path of object to copy
+func TestFileCopy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TODO", func(t *testing.T) {
+		t.Parallel()
+
+		// register wallet
+		// faucet
+		// new alloc
+		// file upload
+		// copy file
+		// list-all
+	})
+
+	// copy to another existing directory
+	// copy to same directory
+	// copy to non-existing directory
+	// copy to directory with existing file with same name
+	// copy with commit
+	// copy to non-existing bad directory
+	// copy non-existing file
+	// copy but no more allocation space
+	// bad allocation
+	// allocation not owned
+
+	// curator scenarios?
+	// collaborator scenarios?
+}

--- a/tests/cli_tests/zboxcli_file_move_test.go
+++ b/tests/cli_tests/zboxcli_file_move_test.go
@@ -1,7 +1,17 @@
 package cli_tests
 
 import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	climodel "github.com/0chain/system_test/internal/cli/model"
+
+	cliutils "github.com/0chain/system_test/internal/cli/util"
+	"github.com/stretchr/testify/require"
 )
 
 //move an object to another folder on blobbers
@@ -18,27 +28,643 @@ import (
 func TestFileMove(t *testing.T) {
 	t.Parallel()
 
-	t.Run("TODO", func(t *testing.T) {
+	t.Run("move file to existing directory", func(t *testing.T) {
 		t.Parallel()
 
-		// register wallet
-		// faucet
-		// new alloc
-		// file upload
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destpath := "/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
 		// move file
+		output, err = moveFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, fmt.Sprintf(remotePath+" moved"), output[0])
+
 		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 2)
+
+		// check if expected file has moved
+		found := false
+		wantNewFilePath := destpath + filename
+		for _, f := range files {
+			if f.Path == wantNewFilePath {
+				found = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.True(t, found, "moved file not found: ", strings.Join(output, "\n"))
 	})
 
-	// move to another existing directory
-	// move to non-existing directory
-	// move file to same directory (no change)
-	// move to directory with existing file with same name
-	// move with commit
-	// move to non-existing bad directory
-	// move non-existing file
-	// bad allocation
-	// allocation not owned
+	t.Run("move file to non-existing directory should fail", func(t *testing.T) {
+		t.Parallel()
 
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/" + filename
+		destpath := "/child/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to move file
+		output, err = moveFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		// FIXME: Error message is incorrect. Should be `Move failed`
+		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 1)
+
+		// check if expected file did not move
+		found := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				found = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.True(t, found, "file at old location is not found: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("move file to same directory (no change) should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/" + filename
+		destpath := "/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to move file
+		output, err = moveFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		// FIXME: Error message is incorrect. Should be `Move failed`
+		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 1)
+
+		// check if file is still there
+		found := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				found = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.True(t, found, "file not found: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("move file to another directory with existing file with same name should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		existingFileInDest := generateRandomTestFileName(t)
+		err = createFileWithSize(existingFileInDest, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/" + filename
+		remotePathAtDest := "/target/" + filename
+		destpath := "/target/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		// upload file to move
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// upload file to another directory with same name.
+		output, err = uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePathAtDest,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected = fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to move file
+		output, err = moveFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		// FIXME: Error message is incorrect. Should be `Move failed`
+		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 3)
+
+		// check if both files are there
+		found := false
+		foundAtTarget := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				found = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+			if f.Path == remotePathAtDest {
+				foundAtTarget = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.True(t, found && foundAtTarget, "both files are not found: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("move file with commit param", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destpath := "/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// move file
+		output, err = moveFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destpath":   destpath,
+			"commit":     "",
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 3)
+
+		require.Equal(t, fmt.Sprintf(remotePath+" moved"), output[0])
+		require.Equal(t, "Commiting changes to blockchain ...", output[1])
+
+		match := reCommitResponse.FindStringSubmatch(output[2])
+		require.Len(t, match, 2)
+
+		var commitResp climodel.CommitResponse
+		err = json.Unmarshal([]byte(match[1]), &commitResp)
+		require.Nil(t, err)
+
+		require.Equal(t, "application/octet-stream", commitResp.MetaData.MimeType)
+		require.Equal(t, fileSize, commitResp.MetaData.Size)
+		require.Equal(t, filepath.Base(filename), commitResp.MetaData.Name)
+		require.Equal(t, remotePath, commitResp.MetaData.Path)
+		require.Equal(t, "", commitResp.MetaData.EncryptedKey)
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 2)
+
+		// check if expected file has moved
+		found := false
+		wantNewFilePath := destpath + filename
+		for _, f := range files {
+			if f.Path == wantNewFilePath {
+				found = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.True(t, found, "moved file not found: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("move non-existing file should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		// try to move a file
+		output, err := moveFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": "/child/nonexisting.txt",
+			"destpath":   "/",
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		// FIXME: Error message is incorrect. Should be `Move failed`
+		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
+	})
+
+	t.Run("move file from someone else's allocation should fail", func(t *testing.T) {
+		t.Parallel()
+
+		nonAllocOwnerWallet := escapedTestName(t) + "_NON_OWNER"
+
+		output, err := registerWalletForName(configPath, nonAllocOwnerWallet)
+		require.Nil(t, err, "registering wallet failed", err, strings.Join(output, "\n"))
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err = createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destpath := "/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err = uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// move file
+		output, err = moveFileForWallet(t, configPath, nonAllocOwnerWallet, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		// FIXME: Error message is incorrect. Should be `Move failed`
+		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 2)
+
+		// check if expected file did not move
+		found := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				found = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.True(t, found, "file at old location is not found: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("move file with no allocation param should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destpath := "/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to move file
+		output, err = moveFile(t, configPath, map[string]interface{}{
+			"remotepath": remotePath,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, "Error: allocation flag is missing", output[0])
+	})
+
+	t.Run("move file with no remotepath param should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destpath := "/"
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to move file
+		output, err = moveFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"destpath":   destpath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, "Error: remotepath flag is missing", output[0])
+	})
+
+	t.Run("move file with no destpath param should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to move file
+		output, err = moveFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, "Error: destpath flag is missing", output[0])
+	})
+
+	// TODO
 	// curator scenarios?
 	// collaborator scenarios?
+}
+
+func moveFile(t *testing.T, cliConfigFilename string, param map[string]interface{}) ([]string, error) {
+	return moveFileForWallet(t, cliConfigFilename, escapedTestName(t), param)
+}
+
+func moveFileForWallet(t *testing.T, cliConfigFilename, wallet string, param map[string]interface{}) ([]string, error) {
+	t.Logf("Moving file...")
+	p := createParams(param)
+	cmd := fmt.Sprintf(
+		"./zbox move %s --silent --wallet %s --configDir ./config --config %s",
+		p,
+		wallet+"_wallet.json",
+		cliConfigFilename,
+	)
+
+	// TODO delete
+	fmt.Println(cmd)
+
+	return cliutils.RunCommandWithRetry(t, cmd, 3, time.Second*20)
 }

--- a/tests/cli_tests/zboxcli_file_move_test.go
+++ b/tests/cli_tests/zboxcli_file_move_test.go
@@ -1,0 +1,44 @@
+package cli_tests
+
+import (
+	"testing"
+)
+
+//move an object to another folder on blobbers
+//
+//Usage:
+//  zbox move [flags]
+//
+//Flags:
+//      --allocation string   Allocation ID
+//      --commit              pass this option to commit the metadata transaction
+//      --destpath string     Destination path for the object. Existing directory the object should be copied to
+//  -h, --help                help for move
+//      --remotepath string   Remote path of object to move
+func TestFileMove(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TODO", func(t *testing.T) {
+		t.Parallel()
+
+		// register wallet
+		// faucet
+		// new alloc
+		// file upload
+		// move file
+		// list-all
+	})
+
+	// move to another existing directory
+	// move to non-existing directory
+	// move file to same directory (no change)
+	// move to directory with existing file with same name
+	// move with commit
+	// move to non-existing bad directory
+	// move non-existing file
+	// bad allocation
+	// allocation not owned
+
+	// curator scenarios?
+	// collaborator scenarios?
+}

--- a/tests/cli_tests/zboxcli_file_move_test.go
+++ b/tests/cli_tests/zboxcli_file_move_test.go
@@ -28,7 +28,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destpath := "/"
 
@@ -58,7 +57,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		})
 		require.Nil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)
-
 		require.Equal(t, fmt.Sprintf(remotePath+" moved"), output[0])
 
 		// list-all
@@ -101,7 +99,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/" + filename
 		destpath := "/child/"
 
@@ -123,15 +120,13 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to move file
 		output, err = moveFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
 			"destpath":   destpath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox move should throw non-zero code
 		require.Len(t, output, 1)
-
 		// FIXME: Error message is incorrect. Should be `Move failed`
 		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
 
@@ -175,7 +170,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/" + filename
 		destpath := "/"
 
@@ -197,15 +191,13 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to move file
 		output, err = moveFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
 			"destpath":   destpath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox move should throw non-zero code
 		require.Len(t, output, 1)
-
 		// FIXME: Error message is incorrect. Should be `Move failed`
 		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
 
@@ -248,7 +240,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/" + filename
 		remotePathAtDest := "/target/" + filename
 		destpath := "/target/"
@@ -286,15 +277,13 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to move file
 		output, err = moveFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
 			"destpath":   destpath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox move should throw non-zero code
 		require.Len(t, output, 1)
-
 		// FIXME: Error message is incorrect. Should be `Move failed`
 		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
 
@@ -342,7 +331,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destpath := "/"
 
@@ -364,7 +352,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// move file
 		output, err = moveFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
@@ -373,7 +360,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		})
 		require.Nil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 3)
-
 		require.Equal(t, fmt.Sprintf(remotePath+" moved"), output[0])
 
 		match := reCommitResponse.FindStringSubmatch(output[2])
@@ -433,9 +419,8 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 			"remotepath": "/child/nonexisting.txt",
 			"destpath":   "/",
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox move should throw non-zero code
 		require.Len(t, output, 1)
-
 		// FIXME: Error message is incorrect. Should be `Move failed`
 		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
 	})
@@ -456,7 +441,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destpath := "/"
 
@@ -478,15 +462,13 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to move file
 		output, err = moveFileForWallet(t, configPath, nonAllocOwnerWallet, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
 			"destpath":   destpath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox move should throw non-zero code
 		require.Len(t, output, 1)
-
 		// FIXME: Error message is incorrect. Should be `Move failed`
 		require.Equal(t, "Copy failed: Copy request failed. Operation failed.", output[0])
 
@@ -530,7 +512,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destpath := "/"
 
@@ -552,14 +533,12 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to move file
 		output, err = moveFile(t, configPath, map[string]interface{}{
 			"remotepath": remotePath,
 			"destpath":   destpath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox move should throw non-zero code
 		require.Len(t, output, 1)
-
 		require.Equal(t, "Error: allocation flag is missing", output[0])
 	})
 
@@ -574,7 +553,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destpath := "/"
 
@@ -596,14 +574,12 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to move file
 		output, err = moveFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"destpath":   destpath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox move should throw non-zero code
 		require.Len(t, output, 1)
-
 		require.Equal(t, "Error: remotepath flag is missing", output[0])
 	})
 
@@ -618,7 +594,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 
 		allocationID := setupAllocation(t, configPath, map[string]interface{}{
@@ -639,14 +614,12 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to move file
 		output, err = moveFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
 		})
-		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox move should throw non-zero code
 		require.Len(t, output, 1)
-
 		require.Equal(t, "Error: destpath flag is missing", output[0])
 	})
 

--- a/tests/cli_tests/zboxcli_file_move_test.go
+++ b/tests/cli_tests/zboxcli_file_move_test.go
@@ -375,6 +375,12 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Equal(t, remotePath, commitResp.MetaData.Path)
 		require.Equal(t, "", commitResp.MetaData.EncryptedKey)
 
+		// verify commit txn
+		output, err = verifyTransaction(t, configPath, commitResp.TxnID)
+		require.Nil(t, err, "Could not verify commit transaction", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "Transaction verification success", output[0])
+
 		// list-all
 		output, err = listAll(t, configPath, allocationID)
 		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))

--- a/tests/cli_tests/zboxcli_file_move_test.go
+++ b/tests/cli_tests/zboxcli_file_move_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFileMove(t *testing.T) {
+func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to have codes all within test.
 	t.Parallel()
 
 	t.Run("move file to existing directory", func(t *testing.T) {
@@ -222,7 +222,7 @@ func TestFileMove(t *testing.T) {
 		// check if file is still there
 		found := false
 		for _, f := range files {
-			if f.Path == remotePath {
+			if f.Path == remotePath { // nolint:gocritic // this is better than inverted if cond
 				found = true
 				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
 				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))

--- a/tests/cli_tests/zboxcli_file_move_test.go
+++ b/tests/cli_tests/zboxcli_file_move_test.go
@@ -622,10 +622,6 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.Len(t, output, 1)
 		require.Equal(t, "Error: destpath flag is missing", output[0])
 	})
-
-	// TODO
-	// curator scenarios?
-	// collaborator scenarios?
 }
 
 func moveFile(t *testing.T, cliConfigFilename string, param map[string]interface{}) ([]string, error) {

--- a/tests/cli_tests/zboxcli_file_move_test.go
+++ b/tests/cli_tests/zboxcli_file_move_test.go
@@ -259,7 +259,6 @@ func TestFileMove(t *testing.T) {
 			"size": allocSize,
 		})
 
-		// upload file to move
 		output, err := uploadFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
@@ -311,12 +310,12 @@ func TestFileMove(t *testing.T) {
 		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
 		require.Len(t, files, 3)
 
-		// check if both files are there
-		found := false
+		// check if both existing files are there
+		foundAtSource := false
 		foundAtTarget := false
 		for _, f := range files {
 			if f.Path == remotePath {
-				found = true
+				foundAtSource = true
 				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
 				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
 				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
@@ -330,7 +329,7 @@ func TestFileMove(t *testing.T) {
 				require.NotEmpty(t, f.Hash)
 			}
 		}
-		require.True(t, found && foundAtTarget, "both files are not found: ", strings.Join(output, "\n"))
+		require.True(t, foundAtSource && foundAtTarget, "both files are not found: ", strings.Join(output, "\n"))
 	})
 
 	t.Run("move file with commit param", func(t *testing.T) {
@@ -377,7 +376,6 @@ func TestFileMove(t *testing.T) {
 		require.Len(t, output, 3)
 
 		require.Equal(t, fmt.Sprintf(remotePath+" moved"), output[0])
-		require.Equal(t, "Commiting changes to blockchain ...", output[1])
 
 		match := reCommitResponse.FindStringSubmatch(output[2])
 		require.Len(t, match, 2)

--- a/tests/cli_tests/zboxcli_file_move_test.go
+++ b/tests/cli_tests/zboxcli_file_move_test.go
@@ -510,38 +510,13 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 	t.Run("move file with no allocation param should fail", func(t *testing.T) {
 		t.Parallel()
 
-		allocSize := int64(2048)
-		fileSize := int64(256)
-
-		file := generateRandomTestFileName(t)
-		err := createFileWithSize(file, fileSize)
-		require.Nil(t, err)
-
-		filename := filepath.Base(file)
-		remotePath := "/child/" + filename
-		destpath := "/"
-
-		allocationID := setupAllocation(t, configPath, map[string]interface{}{
-			"size": allocSize,
-		})
-
-		output, err := uploadFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
-			"localpath":  file,
-		})
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2)
-
-		expected := fmt.Sprintf(
-			"Status completed callback. Type = application/octet-stream. Name = %s",
-			filepath.Base(file),
-		)
-		require.Equal(t, expected, output[1])
+		// unused wallet, just added to avoid having the creating new wallet outputs on move
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
 		output, err = moveFile(t, configPath, map[string]interface{}{
-			"remotepath": remotePath,
-			"destpath":   destpath,
+			"remotepath": "/abc.txt",
+			"destpath":   "/child/",
 		})
 		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox move should throw non-zero code
 		require.Len(t, output, 1)
@@ -551,38 +526,13 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 	t.Run("move file with no remotepath param should fail", func(t *testing.T) {
 		t.Parallel()
 
-		allocSize := int64(2048)
-		fileSize := int64(256)
-
-		file := generateRandomTestFileName(t)
-		err := createFileWithSize(file, fileSize)
-		require.Nil(t, err)
-
-		filename := filepath.Base(file)
-		remotePath := "/child/" + filename
-		destpath := "/"
-
-		allocationID := setupAllocation(t, configPath, map[string]interface{}{
-			"size": allocSize,
-		})
-
-		output, err := uploadFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
-			"localpath":  file,
-		})
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2)
-
-		expected := fmt.Sprintf(
-			"Status completed callback. Type = application/octet-stream. Name = %s",
-			filepath.Base(file),
-		)
-		require.Equal(t, expected, output[1])
+		// unused wallet, just added to avoid having the creating new wallet outputs on move
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
 		output, err = moveFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"destpath":   destpath,
+			"allocation": "abcdef",
+			"destpath":   "/",
 		})
 		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox move should throw non-zero code
 		require.Len(t, output, 1)
@@ -592,37 +542,13 @@ func TestFileMove(t *testing.T) { // nolint:gocyclo // team preference is to hav
 	t.Run("move file with no destpath param should fail", func(t *testing.T) {
 		t.Parallel()
 
-		allocSize := int64(2048)
-		fileSize := int64(256)
-
-		file := generateRandomTestFileName(t)
-		err := createFileWithSize(file, fileSize)
-		require.Nil(t, err)
-
-		filename := filepath.Base(file)
-		remotePath := "/child/" + filename
-
-		allocationID := setupAllocation(t, configPath, map[string]interface{}{
-			"size": allocSize,
-		})
-
-		output, err := uploadFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
-			"localpath":  file,
-		})
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2)
-
-		expected := fmt.Sprintf(
-			"Status completed callback. Type = application/octet-stream. Name = %s",
-			filepath.Base(file),
-		)
-		require.Equal(t, expected, output[1])
+		// unused wallet, just added to avoid having the creating new wallet outputs on move
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
 		output, err = moveFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
+			"allocation": "abcdef",
+			"remotepath": "/abc.txt",
 		})
 		require.Nil(t, err, strings.Join(output, "\n")) // FIXME zbox move should throw non-zero code
 		require.Len(t, output, 1)

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -28,7 +28,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destName := "new_" + filename
 		destPath := "/child/" + destName
@@ -51,7 +50,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		)
 		require.Equal(t, expected, output[1])
 
-		// rename file
 		output, err = renameFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
@@ -59,7 +57,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		})
 		require.Nil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)
-
 		require.Equal(t, fmt.Sprintf(remotePath+" renamed"), output[0])
 
 		// list-all
@@ -102,7 +99,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destName := filename
 
@@ -124,7 +120,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		)
 		require.Equal(t, expected, output[1])
 
-		// rename file
 		output, err = renameFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
@@ -132,7 +127,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		})
 		require.Nil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)
-
 		require.Equal(t, fmt.Sprintf(remotePath+" renamed"), output[0])
 
 		// list-all
@@ -170,7 +164,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 
 		b := make([]rune, 21)
@@ -206,7 +199,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		})
 		require.Nil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)
-
 		require.Equal(t, fmt.Sprintf(remotePath+" renamed"), output[0])
 
 		// list-all
@@ -249,7 +241,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 
 		b := make([]rune, 146)
@@ -277,7 +268,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		)
 		require.Equal(t, expected, output[1])
 
-		// rename file
 		output, err = renameFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
@@ -328,7 +318,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destName := "!@#$%^&*()<>{}[]:;'?,." + filename
 		destPath := "/child/" + destName
@@ -359,7 +348,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		})
 		require.Nil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)
-
 		require.Equal(t, fmt.Sprintf(remotePath+" renamed"), output[0])
 
 		// list-all
@@ -402,7 +390,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destName := "new_" + filename
 		destPath := "/child/" + destName
@@ -425,7 +412,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		)
 		require.Equal(t, expected, output[1])
 
-		// rename file
 		output, err = renameFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
@@ -434,7 +420,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		})
 		require.Nil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 3)
-
 		require.Equal(t, fmt.Sprintf(remotePath+" renamed"), output[0])
 
 		match := reCommitResponse.FindStringSubmatch(output[2])
@@ -515,7 +500,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destName := "new_" + filename
 		destPath := "/child/" + destName
@@ -538,7 +522,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to rename file
 		output, err = renameFileForWallet(t, configPath, nonAllocOwnerWallet, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
@@ -588,7 +571,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destName := "new_" + filename
 
@@ -610,7 +592,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to rename file
 		output, err = renameFile(t, configPath, map[string]interface{}{
 			"remotepath": remotePath,
 			"destname":   destName,
@@ -632,7 +613,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 		destName := "new_" + filename
 
@@ -654,14 +634,12 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to rename file
 		output, err = renameFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"destname":   destName,
 		})
 		require.NotNil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)
-
 		require.Equal(t, "Error: remotepath flag is missing", output[0])
 	})
 
@@ -676,7 +654,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.Nil(t, err)
 
 		filename := filepath.Base(file)
-
 		remotePath := "/child/" + filename
 
 		allocationID := setupAllocation(t, configPath, map[string]interface{}{
@@ -697,14 +674,12 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		)
 		require.Equal(t, expected, output[1])
 
-		// try to rename file
 		output, err = renameFile(t, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotePath,
 		})
 		require.NotNil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)
-
 		require.Equal(t, "Error: destname flag is missing", output[0])
 	})
 

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -1,45 +1,731 @@
 package cli_tests
 
 import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
 	"testing"
-)
+	"time"
 
-// rename an object on blobbers
-//
-//Usage:
-//  zbox rename [flags]
-//
-//Flags:
-//      --allocation string   Allocation ID
-//      --commit              pass this option to commit the metadata transaction
-//      --destname string     New Name for the object (Only the name and not the path). Include the file extension if applicable
-//  -h, --help                help for rename
-//      --remotepath string   Remote path of object to rename
+	climodel "github.com/0chain/system_test/internal/cli/model"
+	"github.com/stretchr/testify/require"
+
+	cliutils "github.com/0chain/system_test/internal/cli/util"
+)
 
 func TestFileRename(t *testing.T) {
 	t.Parallel()
 
-	t.Run("TODO", func(t *testing.T) {
+	t.Run("rename file", func(t *testing.T) {
 		t.Parallel()
 
-		// register wallet
-		// faucet
-		// new alloc
-		// file upload
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destName := "new_" + filename
+		destPath := "/child/" + destName
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
 		// rename file
+		output, err = renameFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destname":   destName,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, fmt.Sprintf(remotePath+" renamed"), output[0])
+
 		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 2)
+
+		// check if expected file has been renamed
+		foundAtSource := false
+		foundAtDest := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				foundAtSource = true
+			}
+			if f.Path == destPath {
+				foundAtDest = true
+				require.Equal(t, destName, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.False(t, foundAtSource, "file is found at source: ", strings.Join(output, "\n"))
+		require.True(t, foundAtDest, "file not found at destination: ", strings.Join(output, "\n"))
 	})
 
-	// rename to new filename with extension
-	// rename to new filename without extension
-	// rename file to same filename (no change)
-	// rename to same filename as existing
-	// rename with commit
-	// rename to bad filename
-	// rename non-existing file
-	// bad allocation
-	// allocation not owned
+	t.Run("rename file to same filename (no change)", func(t *testing.T) {
+		t.Parallel()
 
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destName := filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// rename file
+		output, err = renameFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destname":   destName,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, fmt.Sprintf(remotePath+" renamed"), output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 2)
+
+		// check if file is still there
+		found := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				found = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.True(t, found, "file not found: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("rename file to with 50-char", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+
+		b := make([]rune, 21)
+		for i := range b {
+			b[i] = 'a'
+		}
+		destName := string(b) + ".txt"
+		destPath := "/child/" + destName
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// rename file
+		output, err = renameFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destname":   destName,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, fmt.Sprintf(remotePath+" renamed"), output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 2)
+
+		// check if expected file has not been renamed
+		foundAtSource := false
+		foundAtDest := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				foundAtSource = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+			if f.Path == destPath {
+				foundAtDest = true
+			}
+		}
+		require.False(t, foundAtSource, "file is found at source: ", strings.Join(output, "\n"))
+		require.True(t, foundAtDest, "file not found at destination: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("rename file to with 150-char should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+
+		b := make([]rune, 146)
+		for i := range b {
+			b[i] = 'a'
+		}
+		destName := string(b) + ".txt"
+		destPath := "/child/" + destName
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// rename file
+		output, err = renameFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destname":   destName,
+		})
+		require.NotNil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		//  FIXME: Should be `Renamed failed`
+		require.Equal(t, "Delete failed: Commit consensus failed", output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 2)
+
+		// check if expected file has not been renamed
+		foundAtSource := false
+		foundAtDest := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				foundAtSource = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+			if f.Path == destPath {
+				foundAtDest = true
+			}
+		}
+		require.True(t, foundAtSource, "file not found at source: ", strings.Join(output, "\n"))
+		require.False(t, foundAtDest, "file is found at destination: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("rename file to containing special characters", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destName := "!@#$%^&*()<>{}[]:;'?,." + filename
+		destPath := "/child/" + destName
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// rename file
+		output, err = renameFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destname":   destName,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, fmt.Sprintf(remotePath+" renamed"), output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 2)
+
+		// check if expected file has been renamed
+		foundAtSource := false
+		foundAtDest := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				foundAtSource = true
+			}
+			if f.Path == destPath {
+				foundAtDest = true
+				require.Equal(t, destName, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.False(t, foundAtSource, "file is found at source: ", strings.Join(output, "\n"))
+		require.True(t, foundAtDest, "file not found at destination: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("rename file with commit param", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destName := "new_" + filename
+		destPath := "/child/" + destName
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// rename file
+		output, err = renameFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destname":   destName,
+			"commit":     "",
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 3)
+
+		require.Equal(t, fmt.Sprintf(remotePath+" renamed"), output[0])
+
+		match := reCommitResponse.FindStringSubmatch(output[2])
+		require.Len(t, match, 2)
+
+		var commitResp climodel.CommitResponse
+		err = json.Unmarshal([]byte(match[1]), &commitResp)
+		require.Nil(t, err)
+
+		require.Equal(t, "application/octet-stream", commitResp.MetaData.MimeType)
+		require.Equal(t, fileSize, commitResp.MetaData.Size)
+		require.Equal(t, filepath.Base(filename), commitResp.MetaData.Name)
+		require.Equal(t, remotePath, commitResp.MetaData.Path)
+		require.Equal(t, "", commitResp.MetaData.EncryptedKey)
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 2)
+
+		// check if expected file has been renamed
+		foundAtSource := false
+		foundAtDest := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				foundAtSource = true
+			}
+			if f.Path == destPath {
+				foundAtDest = true
+				require.Equal(t, destName, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+		}
+		require.False(t, foundAtSource, "file is found at source: ", strings.Join(output, "\n"))
+		require.True(t, foundAtDest, "file not found at destination: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("rename non-existing file should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		// try to rename a file
+		output, err := renameFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": "/child/nonexisting.txt",
+			"destname":   "/child/newnonexisting.txt",
+		})
+		require.NotNil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "Rename failed: Rename request failed. Operation failed.", output[0])
+	})
+
+	t.Run("rename file from someone else's allocation should fail", func(t *testing.T) {
+		t.Parallel()
+
+		nonAllocOwnerWallet := escapedTestName(t) + "_NON_OWNER"
+
+		output, err := registerWalletForName(configPath, nonAllocOwnerWallet)
+		require.Nil(t, err, "registering wallet failed", err, strings.Join(output, "\n"))
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err = createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destName := "new_" + filename
+		destPath := "/child/" + destName
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err = uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to rename file
+		output, err = renameFileForWallet(t, configPath, nonAllocOwnerWallet, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"destname":   destName,
+		})
+		require.NotNil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "Rename failed: Rename request failed. Operation failed.", output[0])
+
+		// list-all
+		output, err = listAll(t, configPath, allocationID)
+		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var files []climodel.AllocationFile
+		err = json.NewDecoder(strings.NewReader(output[0])).Decode(&files)
+		require.Nil(t, err, "Error deserializing JSON string `%s`: %v", strings.Join(output, "\n"), err)
+		require.Len(t, files, 2)
+
+		// check if expected file was not renamed
+		foundAtSource := false
+		foundAtDest := false
+		for _, f := range files {
+			if f.Path == remotePath {
+				foundAtSource = true
+				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
+				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))
+				require.Equal(t, "f", f.Type, strings.Join(output, "\n"))
+				require.NotEmpty(t, f.Hash)
+			}
+			if f.Path == destPath {
+				foundAtDest = true
+			}
+		}
+		require.True(t, foundAtSource, "file not found at source: ", strings.Join(output, "\n"))
+		require.False(t, foundAtDest, "file is found at destination: ", strings.Join(output, "\n"))
+	})
+
+	t.Run("rename file with no allocation param should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destName := "new_" + filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to rename file
+		output, err = renameFile(t, configPath, map[string]interface{}{
+			"remotepath": remotePath,
+			"destname":   destName,
+		})
+		require.NotNil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, "Error: allocation flag is missing", output[0])
+	})
+
+	t.Run("rename file with no remotepath param should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+		destName := "new_" + filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to rename file
+		output, err = renameFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"destname":   destName,
+		})
+		require.NotNil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, "Error: remotepath flag is missing", output[0])
+	})
+
+	t.Run("rename file with no destname param should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+
+		remotePath := "/child/" + filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// try to rename file
+		output, err = renameFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+		})
+		require.NotNil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		require.Equal(t, "Error: destname flag is missing", output[0])
+	})
+
+	// TODO
 	// curator scenarios?
 	// collaborator scenarios?
+}
+
+func renameFile(t *testing.T, cliConfigFilename string, param map[string]interface{}) ([]string, error) {
+	return renameFileForWallet(t, cliConfigFilename, escapedTestName(t), param)
+}
+
+func renameFileForWallet(t *testing.T, cliConfigFilename, wallet string, param map[string]interface{}) ([]string, error) {
+	t.Logf("Renaming file...")
+	p := createParams(param)
+	cmd := fmt.Sprintf(
+		"./zbox rename %s --silent --wallet %s --configDir ./config --config %s",
+		p,
+		wallet+"_wallet.json",
+		cliConfigFilename,
+	)
+
+	return cliutils.RunCommandWithRetry(t, cmd, 3, time.Second*20)
 }

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -153,7 +153,7 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.True(t, found, "file not found: ", strings.Join(output, "\n"))
 	})
 
-	t.Run("rename file to with 50-char", func(t *testing.T) {
+	t.Run("rename file to with 90-char (below 100-char filename limit)", func(t *testing.T) {
 		t.Parallel()
 
 		allocSize := int64(2048)
@@ -166,7 +166,7 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		filename := filepath.Base(file)
 		remotePath := "/child/" + filename
 
-		b := make([]rune, 21)
+		b := make([]rune, 90-4) // substract chars for extension
 		for i := range b {
 			b[i] = 'a'
 		}
@@ -230,7 +230,7 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.True(t, foundAtDest, "file not found at destination: ", strings.Join(output, "\n"))
 	})
 
-	t.Run("rename file to with 150-char should fail", func(t *testing.T) {
+	t.Run("rename file to with 110-char (above 100-char filename limit) should fail", func(t *testing.T) {
 		t.Parallel()
 
 		allocSize := int64(2048)
@@ -243,7 +243,7 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		filename := filepath.Base(file)
 		remotePath := "/child/" + filename
 
-		b := make([]rune, 146)
+		b := make([]rune, 110-4) // substract chars for extension
 		for i := range b {
 			b[i] = 'a'
 		}

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -1,0 +1,45 @@
+package cli_tests
+
+import (
+	"testing"
+)
+
+// rename an object on blobbers
+//
+//Usage:
+//  zbox rename [flags]
+//
+//Flags:
+//      --allocation string   Allocation ID
+//      --commit              pass this option to commit the metadata transaction
+//      --destname string     New Name for the object (Only the name and not the path). Include the file extension if applicable
+//  -h, --help                help for rename
+//      --remotepath string   Remote path of object to rename
+
+func TestFileRename(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TODO", func(t *testing.T) {
+		t.Parallel()
+
+		// register wallet
+		// faucet
+		// new alloc
+		// file upload
+		// rename file
+		// list-all
+	})
+
+	// rename to new filename with extension
+	// rename to new filename without extension
+	// rename file to same filename (no change)
+	// rename to same filename as existing
+	// rename with commit
+	// rename to bad filename
+	// rename non-existing file
+	// bad allocation
+	// allocation not owned
+
+	// curator scenarios?
+	// collaborator scenarios?
+}

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -14,7 +14,7 @@ import (
 	cliutils "github.com/0chain/system_test/internal/cli/util"
 )
 
-func TestFileRename(t *testing.T) {
+func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to have codes all within test.
 	t.Parallel()
 
 	t.Run("rename file", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestFileRename(t *testing.T) {
 		// check if file is still there
 		found := false
 		for _, f := range files {
-			if f.Path == remotePath {
+			if f.Path == remotePath { // nolint:gocritic // this is better than inverted if cond
 				found = true
 				require.Equal(t, filename, f.Name, strings.Join(output, "\n"))
 				require.Greater(t, f.Size, int(fileSize), strings.Join(output, "\n"))

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -682,10 +682,6 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.Len(t, output, 1)
 		require.Equal(t, "Error: destname flag is missing", output[0])
 	})
-
-	// TODO
-	// curator scenarios?
-	// collaborator scenarios?
 }
 
 func renameFile(t *testing.T, cliConfigFilename string, param map[string]interface{}) ([]string, error) {

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -166,7 +166,7 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		filename := filepath.Base(file)
 		remotePath := "/child/" + filename
 
-		b := make([]rune, 90-4) // substract chars for extension
+		b := make([]rune, 90-4) // subtract chars for extension
 		for i := range b {
 			b[i] = 'a'
 		}
@@ -243,7 +243,7 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		filename := filepath.Base(file)
 		remotePath := "/child/" + filename
 
-		b := make([]rune, 110-4) // substract chars for extension
+		b := make([]rune, 110-4) // subtract chars for extension
 		for i := range b {
 			b[i] = 'a'
 		}

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -435,6 +435,12 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 		require.Equal(t, remotePath, commitResp.MetaData.Path)
 		require.Equal(t, "", commitResp.MetaData.EncryptedKey)
 
+		// verify commit txn
+		output, err = verifyTransaction(t, configPath, commitResp.TxnID)
+		require.Nil(t, err, "Could not verify commit transaction", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "Transaction verification success", output[0])
+
 		// list-all
 		output, err = listAll(t, configPath, allocationID)
 		require.Nil(t, err, "Unexpected list all failure %s", strings.Join(output, "\n"))

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -569,38 +569,13 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 	t.Run("rename file with no allocation param should fail", func(t *testing.T) {
 		t.Parallel()
 
-		allocSize := int64(2048)
-		fileSize := int64(256)
-
-		file := generateRandomTestFileName(t)
-		err := createFileWithSize(file, fileSize)
-		require.Nil(t, err)
-
-		filename := filepath.Base(file)
-		remotePath := "/child/" + filename
-		destName := "new_" + filename
-
-		allocationID := setupAllocation(t, configPath, map[string]interface{}{
-			"size": allocSize,
-		})
-
-		output, err := uploadFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
-			"localpath":  file,
-		})
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2)
-
-		expected := fmt.Sprintf(
-			"Status completed callback. Type = application/octet-stream. Name = %s",
-			filepath.Base(file),
-		)
-		require.Equal(t, expected, output[1])
+		// unused wallet, just added to avoid having the creating new wallet outputs on rename
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
 		output, err = renameFile(t, configPath, map[string]interface{}{
-			"remotepath": remotePath,
-			"destname":   destName,
+			"remotepath": "/abc.txt",
+			"destname":   "def.txt",
 		})
 		require.NotNil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)
@@ -611,38 +586,13 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 	t.Run("rename file with no remotepath param should fail", func(t *testing.T) {
 		t.Parallel()
 
-		allocSize := int64(2048)
-		fileSize := int64(256)
-
-		file := generateRandomTestFileName(t)
-		err := createFileWithSize(file, fileSize)
-		require.Nil(t, err)
-
-		filename := filepath.Base(file)
-		remotePath := "/child/" + filename
-		destName := "new_" + filename
-
-		allocationID := setupAllocation(t, configPath, map[string]interface{}{
-			"size": allocSize,
-		})
-
-		output, err := uploadFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
-			"localpath":  file,
-		})
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2)
-
-		expected := fmt.Sprintf(
-			"Status completed callback. Type = application/octet-stream. Name = %s",
-			filepath.Base(file),
-		)
-		require.Equal(t, expected, output[1])
+		// unused wallet, just added to avoid having the creating new wallet outputs on rename
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
 		output, err = renameFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"destname":   destName,
+			"allocation": "abcdef",
+			"destname":   "def.txt",
 		})
 		require.NotNil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)
@@ -652,37 +602,13 @@ func TestFileRename(t *testing.T) { // nolint:gocyclo // team preference is to h
 	t.Run("rename file with no destname param should fail", func(t *testing.T) {
 		t.Parallel()
 
-		allocSize := int64(2048)
-		fileSize := int64(256)
-
-		file := generateRandomTestFileName(t)
-		err := createFileWithSize(file, fileSize)
-		require.Nil(t, err)
-
-		filename := filepath.Base(file)
-		remotePath := "/child/" + filename
-
-		allocationID := setupAllocation(t, configPath, map[string]interface{}{
-			"size": allocSize,
-		})
-
-		output, err := uploadFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
-			"localpath":  file,
-		})
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2)
-
-		expected := fmt.Sprintf(
-			"Status completed callback. Type = application/octet-stream. Name = %s",
-			filepath.Base(file),
-		)
-		require.Equal(t, expected, output[1])
+		// unused wallet, just added to avoid having the creating new wallet outputs on rename
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
 		output, err = renameFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
+			"allocation": "abcdef",
+			"remotepath": "/abc.txt",
 		})
 		require.NotNil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)

--- a/tests/cli_tests/zboxcli_file_update_attributes_test.go
+++ b/tests/cli_tests/zboxcli_file_update_attributes_test.go
@@ -1,0 +1,41 @@
+package cli_tests
+
+import (
+	"testing"
+)
+
+// update object attributes on blobbers
+//
+//Usage:
+//  zbox update-attributes [flags]
+//
+//Flags:
+//      --allocation string           Allocation ID
+//      --commit                      pass this option to commit the metadata transaction
+//  -h, --help                        help for update-attributes
+//      --remotepath string           Remote path of object to rename
+//      --who-pays-for-reads string   Who pays for reads: owner or 3rd_party (default "owner")
+func TestFileUpdateAttributes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TODO", func(t *testing.T) {
+		t.Parallel()
+
+		// register wallet
+		// faucet
+		// new alloc
+		// file upload
+		// update file attributes
+		// list-all
+	})
+
+	// update attributes of existing file
+	// update attributes of existing file (no change)
+	// update attributes with commit
+	// update attributes of non-existing file
+	// bad allocation
+	// allocation not owned
+
+	// curator scenarios?
+	// collaborator scenarios?
+}

--- a/tests/cli_tests/zboxcli_file_update_attributes_test.go
+++ b/tests/cli_tests/zboxcli_file_update_attributes_test.go
@@ -288,36 +288,12 @@ func TestFileUpdateAttributes(t *testing.T) {
 	t.Run("update file attributes with no allocation param should fail", func(t *testing.T) {
 		t.Parallel()
 
-		allocSize := int64(2048)
-		fileSize := int64(256)
-
-		file := generateRandomTestFileName(t)
-		err := createFileWithSize(file, fileSize)
-		require.Nil(t, err)
-
-		filename := filepath.Base(file)
-		remotePath := "/child/" + filename
-
-		allocationID := setupAllocation(t, configPath, map[string]interface{}{
-			"size": allocSize,
-		})
-
-		output, err := uploadFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
-			"localpath":  file,
-		})
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2)
-
-		expected := fmt.Sprintf(
-			"Status completed callback. Type = application/octet-stream. Name = %s",
-			filepath.Base(file),
-		)
-		require.Equal(t, expected, output[1])
+		// unused wallet, just added to avoid having the creating new wallet outputs on update file attributes
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
 		output, err = updateFileAttributes(t, configPath, map[string]interface{}{
-			"remotepath":         remotePath,
+			"remotepath":         "/abc.txt",
 			"who-pays-for-reads": "3rd_party",
 		})
 		require.NotNil(t, err, strings.Join(output, "\n"))
@@ -328,36 +304,12 @@ func TestFileUpdateAttributes(t *testing.T) {
 	t.Run("update file attributes with no remotepath param should fail", func(t *testing.T) {
 		t.Parallel()
 
-		allocSize := int64(2048)
-		fileSize := int64(256)
-
-		file := generateRandomTestFileName(t)
-		err := createFileWithSize(file, fileSize)
-		require.Nil(t, err)
-
-		filename := filepath.Base(file)
-		remotePath := "/child/" + filename
-
-		allocationID := setupAllocation(t, configPath, map[string]interface{}{
-			"size": allocSize,
-		})
-
-		output, err := uploadFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
-			"localpath":  file,
-		})
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2)
-
-		expected := fmt.Sprintf(
-			"Status completed callback. Type = application/octet-stream. Name = %s",
-			filepath.Base(file),
-		)
-		require.Equal(t, expected, output[1])
+		// unused wallet, just added to avoid having the creating new wallet outputs on update file attributes
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
 		output, err = updateFileAttributes(t, configPath, map[string]interface{}{
-			"allocation":         allocationID,
+			"allocation":         "abcdef",
 			"who-pays-for-reads": "3rd_party",
 		})
 		require.NotNil(t, err, strings.Join(output, "\n"))

--- a/tests/cli_tests/zboxcli_file_update_attributes_test.go
+++ b/tests/cli_tests/zboxcli_file_update_attributes_test.go
@@ -1,41 +1,365 @@
 package cli_tests
 
 import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	climodel "github.com/0chain/system_test/internal/cli/model"
+
+	cliutils "github.com/0chain/system_test/internal/cli/util"
+	"github.com/stretchr/testify/require"
 )
 
-// update object attributes on blobbers
-//
-//Usage:
-//  zbox update-attributes [flags]
-//
-//Flags:
-//      --allocation string           Allocation ID
-//      --commit                      pass this option to commit the metadata transaction
-//  -h, --help                        help for update-attributes
-//      --remotepath string           Remote path of object to rename
-//      --who-pays-for-reads string   Who pays for reads: owner or 3rd_party (default "owner")
 func TestFileUpdateAttributes(t *testing.T) {
 	t.Parallel()
 
-	t.Run("TODO", func(t *testing.T) {
+	t.Run("update file attribtes of existing file", func(t *testing.T) {
 		t.Parallel()
 
-		// register wallet
-		// faucet
-		// new alloc
-		// file upload
-		// update file attributes
-		// list-all
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+		remotePath := "/child/" + filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation":              allocationID,
+			"remotepath":              remotePath,
+			"localpath":               file,
+			"attr-who-pays-for-reads": "owner",
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		output, err = updateFileAttributes(t, configPath, map[string]interface{}{
+			"allocation":         allocationID,
+			"remotepath":         remotePath,
+			"who-pays-for-reads": "3rd_party",
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "attributes updated", output[0])
 	})
 
-	// update attributes of existing file
-	// update attributes of existing file (no change)
-	// update attributes with commit
-	// update attributes of non-existing file
-	// bad allocation
-	// allocation not owned
+	t.Run("update attributes of existing file (no change)", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+		remotePath := "/child/" + filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation":              allocationID,
+			"remotepath":              remotePath,
+			"localpath":               file,
+			"attr-who-pays-for-reads": "owner",
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		output, err = updateFileAttributes(t, configPath, map[string]interface{}{
+			"allocation":         allocationID,
+			"remotepath":         remotePath,
+			"who-pays-for-reads": "owner",
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "no changes", output[0])
+	})
+
+	t.Run("update file attributes with commit param", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+		remotePath := "/child/" + filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation":              allocationID,
+			"remotepath":              remotePath,
+			"localpath":               file,
+			"attr-who-pays-for-reads": "owner",
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		output, err = updateFileAttributes(t, configPath, map[string]interface{}{
+			"allocation":         allocationID,
+			"remotepath":         remotePath,
+			"who-pays-for-reads": "3rd_party",
+			"commit":             "",
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 3)
+		require.Equal(t, "attributes updated", output[0])
+
+		match := reCommitResponse.FindStringSubmatch(output[2])
+		require.Len(t, match, 2)
+
+		var commitResp climodel.CommitResponse
+		err = json.Unmarshal([]byte(match[1]), &commitResp)
+		require.Nil(t, err)
+
+		require.Equal(t, "application/octet-stream", commitResp.MetaData.MimeType)
+		require.Equal(t, fileSize, commitResp.MetaData.Size)
+		require.Equal(t, filepath.Base(filename), commitResp.MetaData.Name)
+		require.Equal(t, remotePath, commitResp.MetaData.Path)
+		require.Equal(t, "", commitResp.MetaData.EncryptedKey)
+	})
+
+	t.Run("update attributes of non-existing file should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := updateFileAttributes(t, configPath, map[string]interface{}{
+			"allocation":         allocationID,
+			"remotepath":         "/child/nonexisting.txt",
+			"who-pays-for-reads": "3rd_party",
+		})
+		require.NotNil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "fetching the metadata: file_meta_error: Error getting the file meta data from blobbers", output[0])
+	})
+
+	t.Run("update file attributes from someone else's allocation should fail", func(t *testing.T) {
+		t.Parallel()
+
+		nonAllocOwnerWallet := escapedTestName(t) + "_NON_OWNER"
+
+		output, err := registerWalletForName(configPath, nonAllocOwnerWallet)
+		require.Nil(t, err, "registering wallet failed", err, strings.Join(output, "\n"))
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err = createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+		remotePath := "/child/" + filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err = uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		// update file attributes
+		output, err = updateFileAttributesForWallet(t, configPath, nonAllocOwnerWallet, map[string]interface{}{
+			"allocation":         allocationID,
+			"remotepath":         remotePath,
+			"who-pays-for-reads": "3rd_party",
+		})
+		require.NotNil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "fetching the metadata: file_meta_error: Error getting the file meta data from blobbers", output[0])
+	})
+
+	t.Run("update file attributes with no allocation param should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+		remotePath := "/child/" + filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		output, err = updateFileAttributes(t, configPath, map[string]interface{}{
+			"remotepath":         remotePath,
+			"who-pays-for-reads": "3rd_party",
+		})
+		require.NotNil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "missing 'allocation' flag", output[0])
+	})
+
+	t.Run("update file attributes with no remotepath param should fail", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+		remotePath := "/child/" + filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		output, err = updateFileAttributes(t, configPath, map[string]interface{}{
+			"allocation":         allocationID,
+			"who-pays-for-reads": "3rd_party",
+		})
+		require.NotNil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "missing 'remotepath' flag", output[0])
+	})
+
+	t.Run("update file attributes with no who-pays-for-reads param", func(t *testing.T) {
+		t.Parallel()
+
+		allocSize := int64(2048)
+		fileSize := int64(256)
+
+		file := generateRandomTestFileName(t)
+		err := createFileWithSize(file, fileSize)
+		require.Nil(t, err)
+
+		filename := filepath.Base(file)
+		remotePath := "/child/" + filename
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": allocSize,
+		})
+
+		output, err := uploadFile(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+			"localpath":  file,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(file),
+		)
+		require.Equal(t, expected, output[1])
+
+		output, err = updateFileAttributes(t, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotePath,
+		})
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "no changes", output[0])
+	})
 
 	// curator scenarios?
 	// collaborator scenarios?
+}
+
+func updateFileAttributes(t *testing.T, cliConfigFilename string, param map[string]interface{}) ([]string, error) {
+	return updateFileAttributesForWallet(t, cliConfigFilename, escapedTestName(t), param)
+}
+
+func updateFileAttributesForWallet(t *testing.T, cliConfigFilename, wallet string, param map[string]interface{}) ([]string, error) {
+	t.Logf("Updating file attributes...")
+	p := createParams(param)
+	cmd := fmt.Sprintf(
+		"./zbox update-attributes %s --silent --wallet %s --configDir ./config --config %s",
+		p,
+		wallet+"_wallet.json",
+		cliConfigFilename,
+	)
+
+	return cliutils.RunCommandWithRetry(t, cmd, 3, time.Second*20)
 }

--- a/tests/cli_tests/zboxcli_file_update_attributes_test.go
+++ b/tests/cli_tests/zboxcli_file_update_attributes_test.go
@@ -184,6 +184,12 @@ func TestFileUpdateAttributes(t *testing.T) {
 		require.Equal(t, remotePath, commitResp.MetaData.Path)
 		require.Equal(t, "", commitResp.MetaData.EncryptedKey)
 
+		// verify commit txn
+		output, err = verifyTransaction(t, configPath, commitResp.TxnID)
+		require.Nil(t, err, "Could not verify commit transaction", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "Transaction verification success", output[0])
+
 		// check if file attributes was updated
 		output, err = getFileMeta(t, configPath, createParams(map[string]interface{}{
 			"allocation": allocationID,

--- a/tests/cli_tests/zboxcli_list_file_system_test.go
+++ b/tests/cli_tests/zboxcli_list_file_system_test.go
@@ -524,8 +524,7 @@ func createFileWithSize(name string, size int64) error {
 }
 
 func generateRandomTestFileName(t *testing.T) string {
-	path, err := filepath.Abs("tmp")
-	require.Nil(t, err)
+	path := os.TempDir()
 
 	//FIXME: POSSIBLE BUG: when the name of the file is too long, the upload
 	// consensus fails. So we are generating files with random (but short)


### PR DESCRIPTION
Resolves https://github.com/0chain/system_test/issues/73

Adds the following tests
- zbox move
  - move file to existing directory
  - move file to non-existing directory should fail
  - move file to same directory (no change) should fail
  - move file to another directory with existing file with same name should fail
  - move file with commit param
  - move non-existing file should fail
  - move file from someone else's allocation should fail
  - move file with no allocation param should fail
  - move file with no remotepath param should fail
  - move file with no destpath param should fail
- zbox rename
  - rename file
  - rename file to same filename (no change)
  - rename file to with 50-char
  - rename file to with 150-char should fail
  - rename file to containing special characters
  - rename file with commit param
  - rename non-existing file should fail
  - rename file from someone else's allocation should fail
  - rename file with no allocation param should fail
  - rename file with no remotepath param should fail
  - rename file with no destname param should fail
- zbox copy
  - copy file to existing directory
  - copy file to non-existing directory should fail
  - copy file to same directory should fail
  - copy file to another directory with existing file with same name should fail
  - copy file with commit param
  - copy non-existing file should fail
  - copy file from someone else's allocation should fail
  - copy file with no allocation param should fail
  - copy file with no remotepath param should fail
  - copy file with no destpath param should fail
- zbox update-attributes
  - update file attributes of existing file
  - update attributes of existing file (no change)
  - update file attributes with commit param
  - update attributes of non-existing file should fail
  - update file attributes from someone else's allocation should fail
  - update file attributes with no allocation param should fail
  - update file attributes with no remotepath param should fail
  - update file attributes with no who-pays-for-reads param
  
  
To follow:
- token accounting tests for each cmd above
- modification by a curator
- modification by a collaborator