### PR TITLE
add zboxcli's available-after params in share file test

### DIFF
--- a/tests/cli_tests/zboxcli_collaborator_system_test.go
+++ b/tests/cli_tests/zboxcli_collaborator_system_test.go
@@ -405,55 +405,6 @@ func TestCollaborator(t *testing.T) {
 		require.Equal(t, "file_meta_error: Error getting object meta data from blobbers", output[0], "Unexpected output", strings.Join(output, "\n"))
 	})
 
-	t.Run("Remove Collaborator from a file owned by somebody else must fail", func(t *testing.T) {
-		t.Parallel()
-
-		ownerWalletName := escapedTestName(t) + "_owner"
-		anotherWalletName := escapedTestName(t) + "_another"
-
-		allocationID := setupAllocationWithWallet(t, ownerWalletName, configPath, map[string]interface{}{"size": 2 * MB})
-		defer createAllocationTestTeardown(t, allocationID)
-
-		output, err := registerWalletForName(t, configPath, anotherWalletName)
-		require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
-
-		output, err = executeFaucetWithTokensForWallet(t, anotherWalletName, configPath, 1.0)
-		require.Nil(t, err, "faucet execution failed", err, strings.Join(output, "\n"))
-
-		localpath := uploadRandomlyGeneratedFileWithWallet(t, ownerWalletName, allocationID, "/", 128*KB)
-		remotepath := "/" + filepath.Base(localpath)
-
-		thirdPersonWalletAddress := "someone_wallet_address"
-
-		output, err = addCollaboratorWithWallet(t, ownerWalletName, createParams(map[string]interface{}{
-			"allocation": allocationID,
-			"collabid":   thirdPersonWalletAddress,
-			"remotepath": remotepath,
-		}), true)
-		require.Nil(t, err, "error in adding collaborator", strings.Join(output, "\n"))
-		require.Len(t, output, 1, strings.Join(output, "\n"))
-		expectedOutput := fmt.Sprintf("Collaborator %s added successfully for the file %s", thirdPersonWalletAddress, remotepath)
-		require.Equal(t, expectedOutput, output[0], strings.Join(output, "\n"))
-
-		meta := getMetaDataWithWallet(t, ownerWalletName, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotepath,
-			"json":       "",
-		})
-		require.Equal(t, 1, len(meta.Collaborators), "Collaborator must be added in file collaborators list")
-		require.Equal(t, thirdPersonWalletAddress, meta.Collaborators[0].ClientID, "Collaborator must be added in file collaborators list")
-
-		// Now we test if another wallet can remove from collaborators' list
-		output, err = removeCollaboratorWithWallet(t, anotherWalletName, createParams(map[string]interface{}{
-			"allocation": allocationID,
-			"collabid":   thirdPersonWalletAddress,
-			"remotepath": remotepath,
-		}), false)
-		require.NotNil(t, err, "Remove collaborator must fail since the wallet is not the file owner", strings.Join(output, "\n"))
-		require.Equal(t, 1, len(output), "Unexpected number of output lines", strings.Join(output, "\n"))
-		require.Equal(t, "remove_collaborator_failed: Failed to remove collaborator on all blobbers.", output[0], "Unexpected output", strings.Join(output, "\n"))
-	})
-
 	t.Run("Add Collaborator _ Collaborator should NOT be able to add another collaborator", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/cli_tests/zboxcli_collaborator_system_test.go
+++ b/tests/cli_tests/zboxcli_collaborator_system_test.go
@@ -342,6 +342,69 @@ func TestCollaborator(t *testing.T) {
 		require.Equal(t, "add_collaborator_failed: Failed to add collaborator on all blobbers.", output[0], "Unexpected output", strings.Join(output, "\n"))
 	})
 
+	t.Run("Remove Collaborator _ collaborator must no longer be able to share the file", func(t *testing.T) {
+		t.Parallel()
+
+		collaboratorWalletName := escapedTestName(t) + "_collaborator"
+
+		output, err := registerWalletForName(t, configPath, collaboratorWalletName)
+		require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
+
+		collaboratorWallet, err := getWalletForName(t, configPath, collaboratorWalletName)
+		require.Nil(t, err, "Error occurred when retrieving curator wallet")
+
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{"size": 2 * MB})
+		defer createAllocationTestTeardown(t, allocationID)
+
+		localpath := uploadRandomlyGeneratedFile(t, allocationID, "/", 128*KB)
+		remotepath := "/" + filepath.Base(localpath)
+
+		output, err = addCollaborator(t, createParams(map[string]interface{}{
+			"allocation": allocationID,
+			"collabid":   collaboratorWallet.ClientID,
+			"remotepath": remotepath,
+		}), true)
+		require.Nil(t, err, "error in adding collaborator", strings.Join(output, "\n"))
+
+		meta := getMetaData(t, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotepath,
+			"json":       "",
+		})
+		require.Equal(t, 1, len(meta.Collaborators), "Collaborator must be added in file collaborators list")
+		require.Equal(t, collaboratorWallet.ClientID, meta.Collaborators[0].ClientID, "Collaborator must be added in file collaborators list")
+
+		output, err = shareFileWithWallet(t, collaboratorWalletName, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotepath,
+		})
+		require.Nil(t, err, "Error in sharing the file as collaborator", strings.Join(output, "\n"))
+		require.Len(t, output, 1, "Unexpected number of output lines", strings.Join(output, "\n"))
+		require.Regexp(t, regexp.MustCompile("^Auth Ticket: (.*)$"), output[0], "Unexpected output", strings.Join(output, "\n"))
+
+		output, err = removeCollaborator(t, createParams(map[string]interface{}{
+			"allocation": allocationID,
+			"collabid":   collaboratorWallet.ClientID,
+			"remotepath": remotepath,
+		}), true)
+		require.Nil(t, err, "error in deleting collaborator", strings.Join(output, "\n"))
+
+		meta = getMetaData(t, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotepath,
+			"json":       "",
+		})
+		require.Equal(t, 0, len(meta.Collaborators), "Collaborator must be removed from file collaborators list")
+
+		output, err = shareFileWithWallet(t, collaboratorWalletName, configPath, map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotepath,
+		})
+		require.NotNil(t, err, "Share must fail since the wallet is not collaborator anymore", strings.Join(output, "\n"))
+		require.Equal(t, 1, len(output), "Unexpected number of output lines", strings.Join(output, "\n"))
+		require.Equal(t, "file_meta_error: Error getting object meta data from blobbers", output[0], "Unexpected output", strings.Join(output, "\n"))
+	})
+
 	t.Run("Remove Collaborator from a file owned by somebody else must fail", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/cli_tests/zboxcli_list_file_system_test.go
+++ b/tests/cli_tests/zboxcli_list_file_system_test.go
@@ -19,7 +19,7 @@ import (
 	cliutils "github.com/0chain/system_test/internal/cli/util"
 )
 
-var reAuthToken = regexp.MustCompile(`^Auth token :(.*)$`)
+var reAuthToken = regexp.MustCompile(`^Auth Ticket: (.*)$`)
 
 func TestListFileSystem(t *testing.T) {
 	t.Parallel()

--- a/tests/cli_tests/zboxcli_share_file_test.go
+++ b/tests/cli_tests/zboxcli_share_file_test.go
@@ -1464,7 +1464,7 @@ func TestShareFile(t *testing.T) {
 		}
 	})
 
-	t.Run("Share to public with available-after params should fail ", func(t *testing.T) {
+	t.Run("Share to public with available-after params should fail", func(t *testing.T) {
 		t.Parallel()
 
 		walletOwner := escapedTestName(t)
@@ -1499,8 +1499,6 @@ func TestShareFile(t *testing.T) {
 			"available-after": 1638371309,
 		}
 		output, err = shareFile(t, configPath, shareParams)
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 1, "share file - Unexpected output", strings.Join(output, "\n"))
 		require.Equal(t, "Cannot set available-after if the clientid is empty", output[0],
 			"share file - Unexpected output", strings.Join(output, "\n"))
 

--- a/tests/cli_tests/zboxcli_share_file_test.go
+++ b/tests/cli_tests/zboxcli_share_file_test.go
@@ -1499,9 +1499,9 @@ func TestShareFile(t *testing.T) {
 			"available-after": 1638371309,
 		}
 		output, err = shareFile(t, configPath, shareParams)
+		require.Nil(t, err, "error sharing file")
 		require.Equal(t, "Cannot set available-after if the clientid is empty", output[0],
 			"share file - Unexpected output", strings.Join(output, "\n"))
-
 	})
 
 	t.Run("Download file before available-after params should fail", func(t *testing.T) {

--- a/tests/cli_tests/zboxcli_share_file_test.go
+++ b/tests/cli_tests/zboxcli_share_file_test.go
@@ -1504,7 +1504,7 @@ func TestShareFile(t *testing.T) {
 
 	})
 
-	t.Run("Download file before available-after params should fail ", func(t *testing.T) {
+	t.Run("Download file before available-after params should fail", func(t *testing.T) {
 		t.Parallel()
 
 		walletOwner := escapedTestName(t)
@@ -1565,7 +1565,7 @@ func TestShareFile(t *testing.T) {
 		output, err = downloadFileForWallet(t, receiverWallet, configPath, downloadParams, false)
 		require.NotNil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 2, "download file - Unexpected output", strings.Join(output, "\n"))
-		require.Equal(t, "the file is not available until: "+time.Now().UTC().Format("2006-01-02T15:04:05"), output[1],
+		require.Equal(t, "the file is not available until: "+time.Unix(int64(futureTime), 0).UTC().Format("2006-01-02T15:04:05"), output[1],
 			"download file - Unexpected output", strings.Join(output, "\n"))
 	})
 

--- a/tests/cli_tests/zboxcli_update_allocation_test.go
+++ b/tests/cli_tests/zboxcli_update_allocation_test.go
@@ -524,5 +524,5 @@ func executeFaucetWithTokensForWallet(t *testing.T, wallet, cliConfigFilename st
 		tokens,
 		wallet,
 		cliConfigFilename,
-	), 3, time.Second*5)
+	), 3, time.Second*10)
 }


### PR DESCRIPTION
Adding system_test for available-after in zboxcli (fix 0chain/blobber#439)

- blobber: https://github.com/0chain/blobber/pull/442
- gosdk: https://github.com/0chain/gosdk/pull/331
- zbox: https://github.com/0chain/zboxcli/pull/131
- system_test: https://github.com/0chain/system_test/pull/122