### PR TITLE
add check on length before assignment

### DIFF
--- a/tests/cli_tests/block_rewards_test.go
+++ b/tests/cli_tests/block_rewards_test.go
@@ -358,8 +358,14 @@ func keyValuePairStringToMap(t *testing.T, input []string) (stringMap map[string
 	floatMap = map[string]float64{}
 	for _, tapSeparatedKeyValuePair := range input {
 		kvp := strings.Split(tapSeparatedKeyValuePair, "\t")
-		key := strings.TrimSpace(kvp[0])
-		val := strings.TrimSpace(kvp[1])
+		var key, val string
+		if len(kvp) == 2 {
+			key = strings.TrimSpace(kvp[0])
+			val = strings.TrimSpace(kvp[1])
+		} else if len(kvp) == 1 {
+			key = strings.TrimSpace(kvp[0])
+			val = ""
+		}
 
 		float, err := strconv.ParseFloat(val, 64)
 		if err == nil {

--- a/tests/cli_tests/config/zbox_config.yaml
+++ b/tests/cli_tests/config/zbox_config.yaml
@@ -1,4 +1,4 @@
-block_worker: https://dev-3.devnet-0chain.net/dns
+block_worker: https://dev.0chain.net/dns
 signature_scheme: bls0chain
 min_submit: 50 # in percentage
 min_confirmation: 50 # in percentage


### PR DESCRIPTION
It seems `owner_id` is returned as a single value instead of a pair sometimes,
![image](https://user-images.githubusercontent.com/42718091/146792995-06c5457a-302f-488e-be17-e259b857bb39.png)
which is causing out of bounds `panic` and [blocking PRs](https://github.com/0chain/blobber/runs/4583896134?check_suite_focus=true) for blobber team. Can we get this quick-fix merged?