### PR TITLE
Bug/blobber 401 copy file to non existing dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ on:
         required: false
       blobber_image:
         description: 'blobber DOCKER IMAGE to deploy'
-        default: 'bug/issue-401-copy-file-when-no-dir'
+        default: 'staging'
         required: false
       validator_image:
         description: 'validator DOCKER IMAGE to deploy'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       zbox_cli_branch:
         description: '0Box CLI (branch or commit SHA) which the tests will use'
-        default: 'bug/issue-401-copy-file-when-no-dir'
+        default: 'staging'
         required: true
       zwallet_cli_branch:
         description: '0Wallet CLI (branch or commit SHA) which the tests will use'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       zbox_cli_branch:
         description: '0Box CLI (branch or commit SHA) which the tests will use'
-        default: 'staging'
+        default: 'bug/issue-401-copy-file-when-no-dir'
         required: true
       zwallet_cli_branch:
         description: '0Wallet CLI (branch or commit SHA) which the tests will use'
@@ -26,7 +26,7 @@ on:
         required: false
       blobber_image:
         description: 'blobber DOCKER IMAGE to deploy'
-        default: 'staging'
+        default: 'bug/issue-401-copy-file-when-no-dir'
         required: false
       validator_image:
         description: 'validator DOCKER IMAGE to deploy'

--- a/tests/cli_tests/zboxcli_file_copy_test.go
+++ b/tests/cli_tests/zboxcli_file_copy_test.go
@@ -91,7 +91,7 @@ func TestFileCopy(t *testing.T) { // nolint:gocyclo // team preference is to hav
 		require.True(t, foundAtDest, "file not found at destination: ", strings.Join(output, "\n"))
 	})
 
-	t.Run("copy file to non-existing directory should fail", func(t *testing.T) {
+	t.Run("copy file to non-existing directory should work", func(t *testing.T) {
 		t.Parallel()
 
 		allocSize := int64(2048)


### PR DESCRIPTION
changed testcase related to copy file in non-existing directory.
added handling for copy file in non-existing-dir, it should work.