### PR TITLE
Feat/download case enhancement

### DIFF
--- a/tests/cli_tests/zboxcli_download_test.go
+++ b/tests/cli_tests/zboxcli_download_test.go
@@ -743,6 +743,39 @@ func TestDownload(t *testing.T) {
 		require.NotEqual(t, output[0], "invalid startblock. Please input greater than or equal to 1")
 	})
 
+	t.Run("Download with negative endblock should fail", func(t *testing.T) {
+		t.Parallel()
+
+		// 1 block is of size 655360
+		allocSize := int64(655360 * 4)
+		filesize := int64(655360 * 2)
+		remotepath := "/"
+
+		allocationID := setupAllocationAndReadLock(t, configPath, map[string]interface{}{
+			"size":   allocSize,
+			"tokens": 1,
+		})
+
+		filename := generateFileAndUpload(t, allocationID, remotepath, filesize)
+
+		// Delete the uploaded file, since we will be downloading it now
+		err := os.Remove(filename)
+		require.Nil(t, err)
+
+		endBlock := -6
+		output, err := downloadFile(t, configPath, createParams(map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotepath + filepath.Base(filename),
+			"localpath":  "tmp/",
+			"endblock":   endBlock,
+		}), true)
+		// FIXME: error should not be nil, as this is unexpected behavior.
+		// An empty file is downloaded.
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+		require.NotEqual(t, output[0], "invalid startblock. Please input greater than or equal to 1")
+	})
+
 	t.Run("Download File With commit Flag Should Work", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/cli_tests/zboxcli_download_test.go
+++ b/tests/cli_tests/zboxcli_download_test.go
@@ -674,6 +674,42 @@ func TestDownload(t *testing.T) {
 		require.Equal(t, float64(info.Size()), (float64((endBlock-(startBlock-1)))/float64(data.NumOfBlocks))*float64((filesize)))
 	})
 
+	t.Run("Download File With startblock 0 and non-zero endblock should fail", func(t *testing.T) {
+		t.Parallel()
+
+		// 1 block is of size 655360
+		allocSize := int64(655360 * 4)
+		filesize := int64(655360 * 2)
+		remotepath := "/"
+
+		allocationID := setupAllocationAndReadLock(t, configPath, map[string]interface{}{
+			"size":   allocSize,
+			"tokens": 1,
+		})
+
+		filename := generateFileAndUpload(t, allocationID, remotepath, filesize)
+
+		// Delete the uploaded file, since we will be downloading it now
+		err := os.Remove(filename)
+		require.Nil(t, err)
+
+		startBlock := 0
+		endBlock := 5
+		// Minimum Startblock value should be 1 (since gosdk subtracts 1 from start block, so 0 would lead to startblock being -1).
+		output, err := downloadFile(t, configPath, createParams(map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotepath + filepath.Base(filename),
+			"localpath":  "tmp/",
+			"startblock": startBlock,
+			"endblock":   endBlock,
+		}), true)
+		// FIXME: error should not be nil, as this is unexpected behavior.
+		// An empty File is downloaded instead of first 5 blocks.
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+		require.NotEqual(t, output[0], "invalid startblock. Please input greater than or equal to 1")
+	})
+
 	t.Run("Download File With commit Flag Should Work", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/cli_tests/zboxcli_download_test.go
+++ b/tests/cli_tests/zboxcli_download_test.go
@@ -616,7 +616,7 @@ func TestDownload(t *testing.T) {
 	t.Run("Download File With Only startblock Should Work", func(t *testing.T) {
 		t.Parallel()
 
-		// 1 block is of size 655360, we upload 20 blocks and download 1 block
+		// 1 block is of size 65536
 		allocSize := int64(655360 * 4)
 		filesize := int64(655360 * 2)
 		remotepath := "/"
@@ -674,7 +674,7 @@ func TestDownload(t *testing.T) {
 	t.Run("Download File With Only endblock Should Work", func(t *testing.T) {
 		t.Parallel()
 
-		// 1 block is of size 655360, we upload 20 blocks and download 1 block
+		// 1 block is of size 65536
 		allocSize := int64(655360 * 4)
 		filesize := int64(655360 * 2)
 		remotepath := "/"
@@ -735,7 +735,7 @@ func TestDownload(t *testing.T) {
 	t.Run("Download File With startblock And endblock Should Work", func(t *testing.T) {
 		t.Parallel()
 
-		// 1 block is of size 655360, we upload 20 blocks and download 1 block
+		// 1 block is of size 65536, we upload 20 blocks and download 1 block
 		allocSize := int64(655360 * 4)
 		filesize := int64(655360 * 2)
 		remotepath := "/"
@@ -796,7 +796,7 @@ func TestDownload(t *testing.T) {
 	t.Run("Download File With startblock 0 and non-zero endblock should fail", func(t *testing.T) {
 		t.Parallel()
 
-		// 1 block is of size 655360
+		// 1 block is of size 65536
 		allocSize := int64(655360 * 4)
 		filesize := int64(655360 * 2)
 		remotepath := "/"
@@ -829,10 +829,46 @@ func TestDownload(t *testing.T) {
 		require.NotEqual(t, output[0], "invalid startblock. Please input greater than or equal to 1")
 	})
 
+	t.Run("Download File With endblock greater than number of blocks should fail", func(t *testing.T) {
+		t.Parallel()
+
+		// 1 block is of size 65536
+		allocSize := int64(655360 * 4)
+		filesize := int64(655360 * 2)
+		remotepath := "/"
+
+		allocationID := setupAllocationAndReadLock(t, configPath, map[string]interface{}{
+			"size":   allocSize,
+			"tokens": 1,
+		})
+
+		filename := generateFileAndUpload(t, allocationID, remotepath, filesize)
+
+		// Delete the uploaded file, since we will be downloading it now
+		err := os.Remove(filename)
+		require.Nil(t, err)
+
+		startBlock := 1
+		endBlock := 40
+		// Minimum Startblock value should be 1 (since gosdk subtracts 1 from start block, so 0 would lead to startblock being -1).
+		output, err := downloadFile(t, configPath, createParams(map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotepath + filepath.Base(filename),
+			"localpath":  "tmp/",
+			"startblock": startBlock,
+			"endblock":   endBlock,
+		}), true)
+		// FIXME: error should not be nil, as this is unexpected behavior.
+		// 40 blocks cannot be downloaded as that many blocks don't exist.
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+		require.NotEqual(t, output[0], "invalid startblock. Please input greater than or equal to 1")
+	})
+
 	t.Run("Download with negative startblock should fail", func(t *testing.T) {
 		t.Parallel()
 
-		// 1 block is of size 655360
+		// 1 block is of size 65536
 		allocSize := int64(655360 * 4)
 		filesize := int64(655360 * 2)
 		remotepath := "/"
@@ -865,7 +901,7 @@ func TestDownload(t *testing.T) {
 	t.Run("Download with negative endblock should fail", func(t *testing.T) {
 		t.Parallel()
 
-		// 1 block is of size 655360
+		// 1 block is of size 65536
 		allocSize := int64(655360 * 4)
 		filesize := int64(655360 * 2)
 		remotepath := "/"

--- a/tests/cli_tests/zboxcli_download_test.go
+++ b/tests/cli_tests/zboxcli_download_test.go
@@ -613,6 +613,64 @@ func TestDownload(t *testing.T) {
 		require.Equal(t, originalFileChecksum, downloadedFileChecksum)
 	})
 
+	t.Run("Download File With Only startblock Should Work", func(t *testing.T) {
+		t.Parallel()
+
+		// 1 block is of size 655360, we upload 20 blocks and download 1 block
+		allocSize := int64(655360 * 4)
+		filesize := int64(655360 * 2)
+		remotepath := "/"
+
+		allocationID := setupAllocationAndReadLock(t, configPath, map[string]interface{}{
+			"size":   allocSize,
+			"tokens": 1,
+		})
+
+		filename := generateFileAndUpload(t, allocationID, remotepath, filesize)
+
+		// Delete the uploaded file, since we will be downloading it now
+		err := os.Remove(filename)
+		require.Nil(t, err)
+
+		output, err := getFileStats(t, configPath, createParams(map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": "/" + filepath.Base(filename),
+			"json":       "",
+		}), true)
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+
+		var stats map[string]climodel.FileStats
+
+		err = json.Unmarshal([]byte(output[0]), &stats)
+		require.Nil(t, err)
+		var data climodel.FileStats
+		for _, data = range stats {
+			break
+		}
+
+		startBlock := int64(5) // blocks 5 to 10 should be downloaded
+		output, err = downloadFile(t, configPath, createParams(map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotepath + filepath.Base(filename),
+			"localpath":  "tmp/",
+			"startblock": startBlock,
+		}), true)
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+
+		expected := fmt.Sprintf(
+			"Status completed callback. Type = application/octet-stream. Name = %s",
+			filepath.Base(filename),
+		)
+		require.Equal(t, expected, output[1])
+
+		info, err := os.Stat("tmp/" + filepath.Base(filename))
+		require.Nil(t, err, "error getting file stats")
+		// downloaded file size should equal to ratio of block downloaded by original file size
+		require.Equal(t, float64(info.Size()), (float64((data.NumOfBlocks-(startBlock-1)))/float64(data.NumOfBlocks))*float64((filesize)))
+	})
+
 	t.Run("Download File With startblock And endblock Should Work", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/cli_tests/zboxcli_download_test.go
+++ b/tests/cli_tests/zboxcli_download_test.go
@@ -865,6 +865,41 @@ func TestDownload(t *testing.T) {
 		require.NotEqual(t, output[0], "invalid startblock. Please input greater than or equal to 1")
 	})
 
+	t.Run("Download with endblock less than startblock should fail", func(t *testing.T) {
+		t.Parallel()
+
+		// 1 block is of size 65536
+		allocSize := int64(655360 * 4)
+		filesize := int64(655360 * 2)
+		remotepath := "/"
+
+		allocationID := setupAllocationAndReadLock(t, configPath, map[string]interface{}{
+			"size":   allocSize,
+			"tokens": 1,
+		})
+
+		filename := generateFileAndUpload(t, allocationID, remotepath, filesize)
+
+		// Delete the uploaded file, since we will be downloading it now
+		err := os.Remove(filename)
+		require.Nil(t, err)
+
+		startBlock := 6
+		endBlock := 4
+		output, err := downloadFile(t, configPath, createParams(map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotepath + filepath.Base(filename),
+			"localpath":  "tmp/",
+			"startblock": startBlock,
+			"endblock":   endBlock,
+		}), true)
+		// FIXME: error should not be nil, as this is unexpected behavior.
+		// An empty file is downloaded.
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+		require.NotEqual(t, output[0], "invalid startblock. Please input greater than or equal to 1")
+	})
+
 	t.Run("Download with negative startblock should fail", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/cli_tests/zboxcli_download_test.go
+++ b/tests/cli_tests/zboxcli_download_test.go
@@ -710,6 +710,39 @@ func TestDownload(t *testing.T) {
 		require.NotEqual(t, output[0], "invalid startblock. Please input greater than or equal to 1")
 	})
 
+	t.Run("Download with negative startblock should fail", func(t *testing.T) {
+		t.Parallel()
+
+		// 1 block is of size 655360
+		allocSize := int64(655360 * 4)
+		filesize := int64(655360 * 2)
+		remotepath := "/"
+
+		allocationID := setupAllocationAndReadLock(t, configPath, map[string]interface{}{
+			"size":   allocSize,
+			"tokens": 1,
+		})
+
+		filename := generateFileAndUpload(t, allocationID, remotepath, filesize)
+
+		// Delete the uploaded file, since we will be downloading it now
+		err := os.Remove(filename)
+		require.Nil(t, err)
+
+		startBlock := -6
+		output, err := downloadFile(t, configPath, createParams(map[string]interface{}{
+			"allocation": allocationID,
+			"remotepath": remotepath + filepath.Base(filename),
+			"localpath":  "tmp/",
+			"startblock": startBlock,
+		}), true)
+		// FIXME: error should not be nil, as this is unexpected behavior.
+		// An unexpected amount of blocks are downloaded.
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 2)
+		require.NotEqual(t, output[0], "invalid startblock. Please input greater than or equal to 1")
+	})
+
 	t.Run("Download File With commit Flag Should Work", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Added coverage for `startBlock` and `endBlock` flags with `./zbox download` cmd:
- Download with positive startblock and positive endblock should work
- startblock 0 should fail
- negative startblock should fail
- negative endblock should fail
- download with only startblock should work
- download with only endblock should work
- endblock greater than maximum should fail
- endblock less than startblock should fail