### PR TITLE
Miner/Sharder update settings tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           blobber_stake_image: latest
 
       - name: "Run System tests"
-        uses: 0chain/actions/run-system-tests@mn-update-tests
+        uses: 0chain/actions/run-system-tests@master
         with:
           network: ${{ env.NETWORK_URL }}
           zbox_cli_branch: ${{ env.ZBOX_BRANCH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           blobber_stake_image: latest
 
       - name: "Run System tests"
-        uses: 0chain/actions/run-system-tests@master
+        uses: 0chain/actions/run-system-tests@mn-update-tests
         with:
           network: ${{ env.NETWORK_URL }}
           zbox_cli_branch: ${{ env.ZBOX_BRANCH }}

--- a/internal/cli/model/model.go
+++ b/internal/cli/model/model.go
@@ -372,3 +372,24 @@ type KeyPair struct {
 	PublicKey  string `json:"public_key"`
 	PrivateKey string `json:"private_key"`
 }
+
+type Miner struct {
+	ID                string      `json:"id"`
+	N2NHost           string      `json:"n2n_host"`
+	Host              string      `json:"host"`
+	Port              int         `json:"port"`
+	PublicKey         string      `json:"public_key"`
+	ShortName         string      `json:"short_name"`
+	BuildTag          string      `json:"build_tag"`
+	TotalStake        int         `json:"total_stake"`
+	DelegateWallet    string      `json:"delegate_wallet"`
+	ServiceCharge     float64     `json:"service_charge"`
+	NumberOfDelegates int         `json:"number_of_delegates"`
+	MinStake          int64       `json:"min_stake"`
+	MaxStake          int64       `json:"max_stake"`
+	Stat              interface{} `json:"stat"`
+}
+
+type MinerSCNodes struct {
+	Nodes []Node `json:"Nodes"`
+}

--- a/tests/cli_tests/block_rewards_test.go
+++ b/tests/cli_tests/block_rewards_test.go
@@ -387,7 +387,11 @@ func getMiners(t *testing.T, cliConfigFilename string) ([]string, error) {
 }
 
 func getSharders(t *testing.T, cliConfigFilename string) ([]string, error) {
-	return cliutil.RunCommandWithRawOutput("./zwallet ls-sharders --json --silent --wallet " + escapedTestName(t) + "_wallet.json --configDir ./config --config " + cliConfigFilename)
+	return getShardersForWallet(t, cliConfigFilename, escapedTestName(t))
+}
+
+func getShardersForWallet(t *testing.T, cliConfigFilename, wallet string) ([]string, error) {
+	return cliutil.RunCommandWithRawOutput("./zwallet ls-sharders --json --silent --wallet " + wallet + "_wallet.json --configDir ./config --config " + cliConfigFilename)
 }
 
 func getNodeBaseURL(host string, port int) string {

--- a/tests/cli_tests/main_test.go
+++ b/tests/cli_tests/main_test.go
@@ -11,7 +11,7 @@ import (
 
 const scOwnerWallet = "sc_owner"
 const blobberOwnerWallet = "blobber_owner"
-const minerNodeDelegateWallet = "miner_node_delegate"
+const minerNodeDelegateWalletName = "miner_node_delegate"
 
 var configPath string
 
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 			for _, f := range files {
 				// skip deleting the SC owner wallet and blobber owner wallet
 				if strings.HasSuffix(f, scOwnerWallet+"_wallet.json") || strings.HasSuffix(f, blobberOwnerWallet+"_wallet.json") ||
-					strings.HasSuffix(f, minerNodeDelegateWallet+"_wallet.json") {
+					strings.HasSuffix(f, minerNodeDelegateWalletName+"_wallet.json") {
 					continue
 				}
 				_ = os.Remove(f)

--- a/tests/cli_tests/main_test.go
+++ b/tests/cli_tests/main_test.go
@@ -12,6 +12,7 @@ import (
 const scOwnerWallet = "sc_owner"
 const blobberOwnerWallet = "blobber_owner"
 const minerNodeDelegateWalletName = "miner_node_delegate"
+const sharderNodeDelegateWalletName = "sharder_node_delegate"
 
 var configPath string
 
@@ -28,7 +29,7 @@ func TestMain(m *testing.M) {
 			for _, f := range files {
 				// skip deleting the SC owner wallet and blobber owner wallet
 				if strings.HasSuffix(f, scOwnerWallet+"_wallet.json") || strings.HasSuffix(f, blobberOwnerWallet+"_wallet.json") ||
-					strings.HasSuffix(f, minerNodeDelegateWalletName+"_wallet.json") {
+					strings.HasSuffix(f, minerNodeDelegateWalletName+"_wallet.json") || strings.HasSuffix(f, sharderNodeDelegateWalletName+"_wallet.json") {
 					continue
 				}
 				_ = os.Remove(f)

--- a/tests/cli_tests/main_test.go
+++ b/tests/cli_tests/main_test.go
@@ -27,7 +27,8 @@ func TestMain(m *testing.M) {
 		if files, err := filepath.Glob("./config/*.json"); err == nil {
 			for _, f := range files {
 				// skip deleting the SC owner wallet and blobber owner wallet
-				if strings.HasSuffix(f, scOwnerWallet+"_wallet.json") || strings.HasSuffix(f, blobberOwnerWallet+"_wallet.json") {
+				if strings.HasSuffix(f, scOwnerWallet+"_wallet.json") || strings.HasSuffix(f, blobberOwnerWallet+"_wallet.json") ||
+					strings.HasSuffix(f, minerNodeDelegateWallet+"_wallet.json") {
 					continue
 				}
 				_ = os.Remove(f)

--- a/tests/cli_tests/main_test.go
+++ b/tests/cli_tests/main_test.go
@@ -11,6 +11,7 @@ import (
 
 const scOwnerWallet = "sc_owner"
 const blobberOwnerWallet = "blobber_owner"
+const minerNodeDelegateWallet = "miner_node_delegate"
 
 var configPath string
 

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -1,12 +1,15 @@
 package cli_tests
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
 	"time"
 
+	climodel "github.com/0chain/system_test/internal/cli/model"
 	cliutils "github.com/0chain/system_test/internal/cli/util"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMinerUpdateSettings(t *testing.T) {
@@ -15,10 +18,40 @@ func TestMinerUpdateSettings(t *testing.T) {
 	if _, err := os.Stat("./config/" + minerNodeDelegateWallet + "_wallet.json"); err != nil {
 		t.Skipf("blobber owner wallet located at %s is missing", "./config/"+minerNodeDelegateWallet+"_wallet.json")
 	}
+
+	t.Run("miner update min_stake by delegate wallet should work", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := listMiners(t, configPath, "--json")
+		require.Nil(t, err, "error listing miners")
+		require.Len(t, output, 1)
+
+		var miners climodel.MinerSCNodes
+		err = json.Unmarshal([]byte(output[0]), &miners)
+		require.Nil(t, err, "error unmarshalling ls-miners json output")
+		miner := miners.Nodes[2]
+
+		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":        miner.ID,
+			"min_stake": 1,
+		}))
+		defer func() {
+			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+				"id":        miner.ID,
+				"min_stake": 0,
+			}))
+			require.Nil(t, err, "error reverting miner node settings after test")
+			require.Len(t, output, 1)
+			require.Equal(t, "settings updated", output[0])
+		}()
+		require.Nil(t, err, "error updating min stake in miner node")
+		require.Len(t, output, 1)
+		require.Equal(t, "settings updated", output[0])
+	})
 }
 
 func listMiners(t *testing.T, cliConfigFilename, params string) ([]string, error) {
-	return cliutils.RunCommand(t, fmt.Sprintf("./zbox ls-miners %s --silent --wallet %s_wallet.json --configDir ./config --config %s", params, escapedTestName(t), cliConfigFilename), 3, time.Second*2)
+	return cliutils.RunCommand(t, fmt.Sprintf("./zwallet ls-miners %s --silent --wallet %s_wallet.json --configDir ./config --config %s", params, minerNodeDelegateWallet, cliConfigFilename), 3, time.Second*2)
 }
 
 func minerUpdateSettings(t *testing.T, cliConfigFilename, params string) ([]string, error) {
@@ -27,5 +60,5 @@ func minerUpdateSettings(t *testing.T, cliConfigFilename, params string) ([]stri
 
 func minerUpdateSettingsForWallet(t *testing.T, cliConfigFilename, params, wallet string) ([]string, error) {
 	t.Log("Updating miner settings...")
-	return cliutils.RunCommand(t, fmt.Sprintf("./zbox mn-update-settings %s --silent --wallet %s_wallet.json --configDir ./config --config %s", params, wallet, cliConfigFilename), 3, time.Second*2)
+	return cliutils.RunCommand(t, fmt.Sprintf("./zwallet mn-update-settings %s --silent --wallet %s_wallet.json --configDir ./config --config %s", params, wallet, cliConfigFilename), 3, time.Second*2)
 }

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -21,20 +21,19 @@ func TestMinerUpdateSettings(t *testing.T) {
 	}
 
 	mnConfig := getMinerSCConfiguration(t)
+	output, err := listMiners(t, configPath, "--json")
+	require.Nil(t, err, "error listing miners")
+	require.Len(t, output, 1)
+
+	var miners climodel.MinerSCNodes
+	err = json.Unmarshal([]byte(output[0]), &miners)
+	require.Nil(t, err, "error unmarshalling ls-miners json output")
+	miner := miners.Nodes[2]
 
 	t.Run("Miner update min_stake by delegate wallet should work", func(t *testing.T) {
 		t.Parallel()
 
-		output, err := listMiners(t, configPath, "--json")
-		require.Nil(t, err, "error listing miners")
-		require.Len(t, output, 1)
-
-		var miners climodel.MinerSCNodes
-		err = json.Unmarshal([]byte(output[0]), &miners)
-		require.Nil(t, err, "error unmarshalling ls-miners json output")
-		miner := miners.Nodes[2]
-
-		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
 			"min_stake": 1,
 		}), true)
@@ -59,17 +58,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	t.Run("Miner update num_delegates by delegate wallet should work", func(t *testing.T) {
 		t.Parallel()
 
-		output, err := listMiners(t, configPath, "--json")
-		require.Nil(t, err, "error listing miners")
-		require.Len(t, output, 1)
-
-		var miners climodel.MinerSCNodes
-		err = json.Unmarshal([]byte(output[0]), &miners)
-		require.Nil(t, err, "error unmarshalling ls-miners json output")
-
-		miner := miners.Nodes[2]
-
-		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":            miner.ID,
 			"num_delegates": 5,
 		}), true)
@@ -90,17 +79,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	t.Run("Miner update max_stake with delegate wallet should work", func(t *testing.T) {
 		t.Parallel()
 
-		output, err := listMiners(t, configPath, "--json")
-		require.Nil(t, err, "error listing miners")
-		require.Len(t, output, 1)
-
-		var miners climodel.MinerSCNodes
-		err = json.Unmarshal([]byte(output[0]), &miners)
-		require.Nil(t, err, "error unmarshalling ls-miners json output")
-
-		miner := miners.Nodes[2]
-
-		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
 			"max_stake": 99,
 		}), true)
@@ -121,17 +100,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	t.Run("Miner update min_stake with less than global min stake should fail", func(t *testing.T) {
 		t.Parallel()
 
-		output, err := listMiners(t, configPath, "--json")
-		require.Nil(t, err, "error listing miners")
-		require.Len(t, output, 1)
-
-		var miners climodel.MinerSCNodes
-		err = json.Unmarshal([]byte(output[0]), &miners)
-		require.Nil(t, err, "error unmarshalling ls-miners json output")
-
-		miner := miners.Nodes[2]
-
-		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
 			"min_stake": mnConfig["min_stake"] - 1e-10,
 		}), false)
@@ -152,17 +121,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	t.Run("Miner update num_delegates greater than global max_delegates should fail", func(t *testing.T) {
 		t.Parallel()
 
-		output, err := listMiners(t, configPath, "--json")
-		require.Nil(t, err, "error listing miners")
-		require.Len(t, output, 1)
-
-		var miners climodel.MinerSCNodes
-		err = json.Unmarshal([]byte(output[0]), &miners)
-		require.Nil(t, err, "error unmarshalling ls-miners json output")
-
-		miner := miners.Nodes[2]
-
-		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":            miner.ID,
 			"num_delegates": mnConfig["max_delegates"] + 1,
 		}), false)
@@ -183,17 +142,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	t.Run("Miner update max_stake greater than global max_stake should fail", func(t *testing.T) {
 		t.Parallel()
 
-		output, err := listMiners(t, configPath, "--json")
-		require.Nil(t, err, "error listing miners")
-		require.Len(t, output, 1)
-
-		var miners climodel.MinerSCNodes
-		err = json.Unmarshal([]byte(output[0]), &miners)
-		require.Nil(t, err, "error unmarshalling ls-miners json output")
-
-		miner := miners.Nodes[2]
-
-		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
 			"max_stake": mnConfig["max_stake"] + 1e-10,
 		}), false)
@@ -214,17 +163,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	t.Run("Miner update min_stake negative value should fail", func(t *testing.T) {
 		t.Parallel()
 
-		output, err := listMiners(t, configPath, "--json")
-		require.Nil(t, err, "error listing miners")
-		require.Len(t, output, 1)
-
-		var miners climodel.MinerSCNodes
-		err = json.Unmarshal([]byte(output[0]), &miners)
-		require.Nil(t, err, "error unmarshalling ls-miners json output")
-
-		miner := miners.Nodes[2]
-
-		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
 			"min_stake": -1,
 		}), false)
@@ -245,17 +184,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	t.Run("Miner update max_stake negative value should fail", func(t *testing.T) {
 		t.Parallel()
 
-		output, err := listMiners(t, configPath, "--json")
-		require.Nil(t, err, "error listing miners")
-		require.Len(t, output, 1)
-
-		var miners climodel.MinerSCNodes
-		err = json.Unmarshal([]byte(output[0]), &miners)
-		require.Nil(t, err, "error unmarshalling ls-miners json output")
-
-		miner := miners.Nodes[2]
-
-		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
 			"max_stake": -1,
 		}), false)
@@ -276,17 +205,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	t.Run("Miner update num_delegate negative value should fail", func(t *testing.T) {
 		t.Parallel()
 
-		output, err := listMiners(t, configPath, "--json")
-		require.Nil(t, err, "error listing miners")
-		require.Len(t, output, 1)
-
-		var miners climodel.MinerSCNodes
-		err = json.Unmarshal([]byte(output[0]), &miners)
-		require.Nil(t, err, "error unmarshalling ls-miners json output")
-
-		miner := miners.Nodes[2]
-
-		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":            miner.ID,
 			"num_delegates": -1,
 		}), false)

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -45,7 +45,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 		defer func() {
 			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 				"id":        miner.ID,
-				"min_stake": miner.MinStake / 1e10, //miner.MinStake is in Int, but config takes params in ZCN
+				"min_stake": miner.MinStake / 1e10, //miner.MinStake is in Int, but this command takes params in ZCN
 			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
@@ -107,7 +107,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 		defer func() {
 			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 				"id":        miner.ID,
-				"max_stake": miner.MaxStake / 1e10, // miner.MaxStake is in Int, but config takes params in ZCN
+				"max_stake": miner.MaxStake / 1e10, // miner.MaxStake is in Int, but this command takes params in ZCN
 			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
@@ -138,7 +138,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 		defer func() {
 			output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 				"id":        miner.ID,
-				"min_stake": miner.MinStake / 1e10, //miner.MinStake is in Int, but config takes params in ZCN
+				"min_stake": miner.MinStake / 1e10, //miner.MinStake is in Int, but this command takes params in ZCN
 			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
@@ -200,13 +200,44 @@ func TestMinerUpdateSettings(t *testing.T) {
 		defer func() {
 			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 				"id":        miner.ID,
-				"max_stake": miner.MaxStake / 1e10, //miner.MaxStake is in Int, but config takes params in ZCN
+				"max_stake": miner.MaxStake / 1e10, //miner.MaxStake is in Int, but this command takes params in ZCN
 			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
 			require.Equal(t, "settings updated", output[0])
 		}()
 		require.NotNil(t, err, "expected error when updating max_stake to greater than global max but got output:", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+	})
+
+	t.Run("Miner update min_stake negative value should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := listMiners(t, configPath, "--json")
+		require.Nil(t, err, "error listing miners")
+		require.Len(t, output, 1)
+
+		var miners climodel.MinerSCNodes
+		err = json.Unmarshal([]byte(output[0]), &miners)
+		require.Nil(t, err, "error unmarshalling ls-miners json output")
+
+		miner := miners.Nodes[2]
+
+		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":        miner.ID,
+			"min_stake": -1,
+		}), false)
+		defer func() {
+			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+				"id":        miner.ID,
+				"min_stake": miner.MinStake / 1e10, //miner.MinStake is in Int, but this command takes params in ZCN
+			}), true)
+			require.Nil(t, err, "error reverting miner node settings after test")
+			require.Len(t, output, 1)
+			require.Equal(t, "settings updated", output[0])
+		}()
+		require.NotNil(t, err, "expected error on negative min stake but got output:", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -97,6 +97,31 @@ func TestMinerUpdateSettings(t *testing.T) {
 		require.Equal(t, "settings updated", output[0])
 	})
 
+	t.Run("Miner update multiple settings with delegate wallet should work", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":            miner.ID,
+			"num_delegates": 5,
+			"max_stake":     101,
+			"min_stake":     1,
+		}), true)
+		defer func() {
+			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+				"id":            miner.ID,
+				"num_delegates": miner.NumberOfDelegates,
+				"min_stake":     miner.MinStake / 1e10,
+				"max_stake":     miner.MaxStake / 1e10,
+			}), true)
+			require.Nil(t, err, "error reverting miner settings after test")
+			require.Len(t, output, 1)
+			require.Equal(t, "settings updated", output[0])
+		}()
+		require.Nil(t, err, "error updating multiple settings with delegate wallet")
+		require.Len(t, output, 1)
+		require.Equal(t, "settings updated", output[0])
+	})
+
 	t.Run("Miner update min_stake with less than global min stake should fail", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -17,7 +17,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	t.Parallel()
 
 	if _, err := os.Stat("./config/" + minerNodeDelegateWallet + "_wallet.json"); err != nil {
-		t.Skipf("blobber owner wallet located at %s is missing", "./config/"+minerNodeDelegateWallet+"_wallet.json")
+		t.Skipf("miner node owner wallet located at %s is missing", "./config/"+minerNodeDelegateWallet+"_wallet.json")
 	}
 
 	mnConfig := getMinerSCConfiguration(t)
@@ -93,7 +93,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	t.Run("Miner update max_stake with delegate wallet should work", func(t *testing.T) {
 		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
-			"max_stake": 101,
+			"max_stake": 101, // FIXME: should be 99
 		}), true)
 
 		require.Nil(t, err, "error updating max_stake in miner node")
@@ -116,7 +116,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":            miner.ID,
 			"num_delegates": 5,
-			"max_stake":     99,
+			"max_stake":     101, // FIXME: should be 99
 			"min_stake":     1,
 		}), true)
 		require.Nil(t, err, "error updating multiple settings with delegate wallet")
@@ -133,7 +133,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 		err = json.Unmarshal([]byte(output[0]), &minerInfo)
 		require.Nil(t, err, "error unmarshalling miner info")
 		require.Equal(t, 5, minerInfo.NumberOfDelegates)
-		require.Equal(t, float64(99), intToZCN(minerInfo.MaxStake))
+		require.Equal(t, float64(101), intToZCN(minerInfo.MaxStake))
 		require.Equal(t, float64(1), intToZCN(minerInfo.MinStake))
 	})
 
@@ -168,7 +168,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 
 		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
-			"max_stake": mnConfig["max_stake"] + 1e-10,
+			"max_stake": mnConfig["max_stake"] - 1e-10, // FIXME: should be +
 		}), false)
 
 		require.NotNil(t, err, "expected error when updating max_stake to greater than global max but got output:", strings.Join(output, "\n"))

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,8 @@ func TestMinerUpdateSettings(t *testing.T) {
 	if _, err := os.Stat("./config/" + minerNodeDelegateWallet + "_wallet.json"); err != nil {
 		t.Skipf("blobber owner wallet located at %s is missing", "./config/"+minerNodeDelegateWallet+"_wallet.json")
 	}
+
+	mnConfig := getMinerSCConfiguration(t)
 
 	t.Run("Miner update min_stake by delegate wallet should work", func(t *testing.T) {
 		t.Parallel()
@@ -141,6 +144,46 @@ func TestMinerUpdateSettings(t *testing.T) {
 		require.Nil(t, err, "error updating max_stake in miner node")
 		require.Len(t, output, 1)
 		require.Equal(t, "settings updated", output[0])
+	})
+
+	t.Run("Miner update min_stake with less than global min stake should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := listMiners(t, configPath, "--json")
+		require.Nil(t, err, "error listing miners")
+		require.Len(t, output, 1)
+
+		var miners climodel.MinerSCNodes
+		err = json.Unmarshal([]byte(output[0]), &miners)
+		require.Nil(t, err, "error unmarshalling ls-miners json output")
+
+		miner := miners.Nodes[2]
+		output, err = minerInfo(t, configPath, createParams(map[string]interface{}{
+			"id": miner.ID,
+		}))
+		require.Nil(t, err, "error fetching miner node info")
+		require.Len(t, output, 1)
+
+		var oldMinerInfo climodel.SimpleNode
+		err = json.Unmarshal([]byte(output[0]), &oldMinerInfo)
+		require.Nil(t, err, "error unmarshalling miner info")
+
+		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":        miner.ID,
+			"min_stake": mnConfig["min_stake"] - 1e-9,
+		}), false)
+		defer func() {
+			output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+				"id":        miner.ID,
+				"min_stake": oldMinerInfo.MinStake,
+			}), true)
+			require.Nil(t, err, "error reverting miner node settings after test")
+			require.Len(t, output, 1)
+			require.Equal(t, "settings updated", output[0])
+		}()
+		require.NotNil(t, err, "expected error when updating min_stake less than global min_stake but got output:", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})
 }
 

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -31,7 +31,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	var miners climodel.MinerSCNodes
 	err = json.Unmarshal([]byte(output[0]), &miners)
 	require.Nil(t, err, "error unmarshalling ls-miners json output")
-	
+
 	var miner climodel.Node
 	for _, miner = range miners.Nodes {
 		if miner.ID == minerNodeDelegateWallet.ClientID {

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -34,16 +34,6 @@ func TestMinerUpdateSettings(t *testing.T) {
 		require.Nil(t, err, "error unmarshalling ls-miners json output")
 		miner := miners.Nodes[2]
 
-		output, err = minerInfo(t, configPath, createParams(map[string]interface{}{
-			"id": miner.ID,
-		}))
-		require.Nil(t, err, "error fetching miner node info")
-		require.Len(t, output, 1)
-
-		var oldMinerInfo climodel.SimpleNode
-		err = json.Unmarshal([]byte(output[0]), &oldMinerInfo)
-		require.Nil(t, err, "error unmarshalling miner info")
-
 		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
 			"min_stake": 1,
@@ -55,7 +45,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 		defer func() {
 			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 				"id":        miner.ID,
-				"min_stake": oldMinerInfo.MinStake,
+				"min_stake": miner.MinStake,
 			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
@@ -78,15 +68,6 @@ func TestMinerUpdateSettings(t *testing.T) {
 		require.Nil(t, err, "error unmarshalling ls-miners json output")
 
 		miner := miners.Nodes[2]
-		output, err = minerInfo(t, configPath, createParams(map[string]interface{}{
-			"id": miner.ID,
-		}))
-		require.Nil(t, err, "error fetching miner node info")
-		require.Len(t, output, 1)
-
-		var oldMinerInfo climodel.SimpleNode
-		err = json.Unmarshal([]byte(output[0]), &oldMinerInfo)
-		require.Nil(t, err, "error unmarshalling miner info")
 
 		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":            miner.ID,
@@ -95,7 +76,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 		defer func() {
 			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 				"id":            miner.ID,
-				"num_delegates": oldMinerInfo.NumberOfDelegates,
+				"num_delegates": miner.NumberOfDelegates,
 			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
@@ -118,15 +99,6 @@ func TestMinerUpdateSettings(t *testing.T) {
 		require.Nil(t, err, "error unmarshalling ls-miners json output")
 
 		miner := miners.Nodes[2]
-		output, err = minerInfo(t, configPath, createParams(map[string]interface{}{
-			"id": miner.ID,
-		}))
-		require.Nil(t, err, "error fetching miner node info")
-		require.Len(t, output, 1)
-
-		var oldMinerInfo climodel.SimpleNode
-		err = json.Unmarshal([]byte(output[0]), &oldMinerInfo)
-		require.Nil(t, err, "error unmarshalling miner info")
 
 		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
@@ -135,7 +107,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 		defer func() {
 			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 				"id":        miner.ID,
-				"max_stake": oldMinerInfo.MaxStake,
+				"max_stake": miner.MaxStake,
 			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
@@ -158,15 +130,6 @@ func TestMinerUpdateSettings(t *testing.T) {
 		require.Nil(t, err, "error unmarshalling ls-miners json output")
 
 		miner := miners.Nodes[2]
-		output, err = minerInfo(t, configPath, createParams(map[string]interface{}{
-			"id": miner.ID,
-		}))
-		require.Nil(t, err, "error fetching miner node info")
-		require.Len(t, output, 1)
-
-		var oldMinerInfo climodel.SimpleNode
-		err = json.Unmarshal([]byte(output[0]), &oldMinerInfo)
-		require.Nil(t, err, "error unmarshalling miner info")
 
 		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
@@ -175,7 +138,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 		defer func() {
 			output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 				"id":        miner.ID,
-				"min_stake": oldMinerInfo.MinStake,
+				"min_stake": miner.MinStake,
 			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
@@ -198,15 +161,6 @@ func TestMinerUpdateSettings(t *testing.T) {
 		require.Nil(t, err, "error unmarshalling ls-miners json output")
 
 		miner := miners.Nodes[2]
-		output, err = minerInfo(t, configPath, createParams(map[string]interface{}{
-			"id": miner.ID,
-		}))
-		require.Nil(t, err, "error fetching miner node info")
-		require.Len(t, output, 1)
-
-		var oldMinerInfo climodel.SimpleNode
-		err = json.Unmarshal([]byte(output[0]), &oldMinerInfo)
-		require.Nil(t, err, "error unmarshalling miner info")
 
 		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":            miner.ID,
@@ -215,7 +169,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 		defer func() {
 			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 				"id":            miner.ID,
-				"num_delegates": oldMinerInfo.NumberOfDelegates,
+				"num_delegates": miner.NumberOfDelegates,
 			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
@@ -242,9 +196,4 @@ func minerUpdateSettingsForWallet(t *testing.T, cliConfigFilename, params, walle
 	} else {
 		return cliutils.RunCommandWithoutRetry(fmt.Sprintf("./zwallet mn-update-settings %s --silent --wallet %s_wallet.json --configDir ./config --config %s", params, wallet, cliConfigFilename))
 	}
-}
-
-func minerInfo(t *testing.T, cliConfigFilename, params string) ([]string, error) {
-	t.Log("Fetching miner node info...")
-	return cliutils.RunCommand(t, fmt.Sprintf("./zwallet mn-info %s --silent --wallet %s_wallet.json --configDir ./config --config %s", params, minerNodeDelegateWallet, cliConfigFilename), 3, time.Second*2)
 }

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -99,7 +99,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	t.Run("Miner update max_stake with delegate wallet should work", func(t *testing.T) {
 		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
-			"max_stake": 101, // FIXME: should be 99
+			"max_stake": 99,
 		}), true)
 
 		require.Nil(t, err, "error updating max_stake in miner node")
@@ -115,14 +115,14 @@ func TestMinerUpdateSettings(t *testing.T) {
 		var minerInfo climodel.Node
 		err = json.Unmarshal([]byte(output[0]), &minerInfo)
 		require.Nil(t, err, "error unmarshalling miner info")
-		require.Equal(t, 101, int(intToZCN(minerInfo.MaxStake)))
+		require.Equal(t, 99, int(intToZCN(minerInfo.MaxStake)))
 	})
 
 	t.Run("Miner update multiple settings with delegate wallet should work", func(t *testing.T) {
 		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":            miner.ID,
 			"num_delegates": 5,
-			"max_stake":     101, // FIXME: should be 99
+			"max_stake":     99,
 			"min_stake":     1,
 		}), true)
 		require.Nil(t, err, "error updating multiple settings with delegate wallet")
@@ -139,7 +139,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 		err = json.Unmarshal([]byte(output[0]), &minerInfo)
 		require.Nil(t, err, "error unmarshalling miner info")
 		require.Equal(t, 5, minerInfo.NumberOfDelegates)
-		require.Equal(t, float64(101), intToZCN(minerInfo.MaxStake))
+		require.Equal(t, float64(99), intToZCN(minerInfo.MaxStake))
 		require.Equal(t, float64(1), intToZCN(minerInfo.MinStake))
 	})
 
@@ -174,7 +174,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 
 		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
-			"max_stake": mnConfig["max_stake"] - 1e-10, // FIXME: should be +
+			"max_stake": mnConfig["max_stake"] + 1e-10,
 		}), false)
 
 		require.NotNil(t, err, "expected error when updating max_stake to greater than global max but got output:", strings.Join(output, "\n"))
@@ -185,7 +185,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 	t.Run("Miner update max_stake less than min_stake should fail", func(t *testing.T) {
 		t.Parallel()
 
-		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
 			"min_stake": 51,
 			"max_stake": 48,

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -236,8 +236,8 @@ func TestMinerUpdateSettings(t *testing.T) {
 		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id": miner.ID,
 		}), false)
-		require.Nil(t, err, "output")
 		// FIXME: some indication that no param has been selected to update should be given
+		require.Nil(t, err)
 		require.Len(t, output, 1)
 		require.Equal(t, "settings updated", output[0])
 	})

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -44,7 +44,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
 			"min_stake": 1,
-		}))
+		}), true)
 		require.Nil(t, err, "error reverting miner node settings after test")
 		require.Len(t, output, 1)
 		require.Equal(t, "settings updated", output[0])
@@ -53,7 +53,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 				"id":        miner.ID,
 				"min_stake": oldMinerInfo.MinStake,
-			}))
+			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
 			require.Equal(t, "settings updated", output[0])
@@ -88,12 +88,12 @@ func TestMinerUpdateSettings(t *testing.T) {
 		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":            miner.ID,
 			"num_delegates": 5,
-		}))
+		}), true)
 		defer func() {
 			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 				"id":            miner.ID,
 				"num_delegates": oldMinerInfo.NumberOfDelegates,
-			}))
+			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
 			require.Equal(t, "settings updated", output[0])
@@ -128,12 +128,12 @@ func TestMinerUpdateSettings(t *testing.T) {
 		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        miner.ID,
 			"max_stake": 99,
-		}))
+		}), true)
 		defer func() {
 			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
 				"id":        miner.ID,
 				"max_stake": oldMinerInfo.MaxStake,
-			}))
+			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
 			require.Equal(t, "settings updated", output[0])
@@ -148,13 +148,17 @@ func listMiners(t *testing.T, cliConfigFilename, params string) ([]string, error
 	return cliutils.RunCommand(t, fmt.Sprintf("./zwallet ls-miners %s --silent --wallet %s_wallet.json --configDir ./config --config %s", params, minerNodeDelegateWallet, cliConfigFilename), 3, time.Second*2)
 }
 
-func minerUpdateSettings(t *testing.T, cliConfigFilename, params string) ([]string, error) {
-	return minerUpdateSettingsForWallet(t, cliConfigFilename, params, minerNodeDelegateWallet)
+func minerUpdateSettings(t *testing.T, cliConfigFilename, params string, retry bool) ([]string, error) {
+	return minerUpdateSettingsForWallet(t, cliConfigFilename, params, minerNodeDelegateWallet, retry)
 }
 
-func minerUpdateSettingsForWallet(t *testing.T, cliConfigFilename, params, wallet string) ([]string, error) {
+func minerUpdateSettingsForWallet(t *testing.T, cliConfigFilename, params, wallet string, retry bool) ([]string, error) {
 	t.Log("Updating miner settings...")
-	return cliutils.RunCommand(t, fmt.Sprintf("./zwallet mn-update-settings %s --silent --wallet %s_wallet.json --configDir ./config --config %s", params, wallet, cliConfigFilename), 3, time.Second*2)
+	if retry {
+		return cliutils.RunCommand(t, fmt.Sprintf("./zwallet mn-update-settings %s --silent --wallet %s_wallet.json --configDir ./config --config %s", params, wallet, cliConfigFilename), 3, time.Second*2)
+	} else {
+		return cliutils.RunCommandWithoutRetry(fmt.Sprintf("./zwallet mn-update-settings %s --silent --wallet %s_wallet.json --configDir ./config --config %s", params, wallet, cliConfigFilename))
+	}
 }
 
 func minerInfo(t *testing.T, cliConfigFilename, params string) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -182,6 +182,19 @@ func TestMinerUpdateSettings(t *testing.T) {
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})
 
+	t.Run("Miner update max_stake less than min_stake should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":        miner.ID,
+			"min_stake": 51,
+			"max_stake": 48,
+		}), false)
+		require.NotNil(t, err, "Expected error when trying to update max_stake to less than min_stake but got output:", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+	})
+
 	t.Run("Miner update min_stake negative value should fail", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -17,6 +17,10 @@ func TestMinerUpdateSettings(t *testing.T) {
 	}
 }
 
+func listMiners(t *testing.T, cliConfigFilename, params string) ([]string, error) {
+	return cliutils.RunCommand(t, fmt.Sprintf("./zbox ls-miners %s --silent --wallet %s_wallet.json --configDir ./config --config %s", params, escapedTestName(t), cliConfigFilename), 3, time.Second*2)
+}
+
 func minerUpdateSettings(t *testing.T, cliConfigFilename, params string) ([]string, error) {
 	return minerUpdateSettingsForWallet(t, cliConfigFilename, params, minerNodeDelegateWallet)
 }

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -164,7 +164,7 @@ func TestMinerUpdateSettings(t *testing.T) {
 			"num_delegates": mnConfig["max_delegates"] + 1,
 		}), false)
 
-		require.NotNil(t, err, "expected error when updating num_delegated greater than max allowed but got output:", strings.Join(output, "\n"))
+		require.NotNil(t, err, "expected error when updating num_delegates greater than max allowed but got output:", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -1,0 +1,27 @@
+package cli_tests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	cliutils "github.com/0chain/system_test/internal/cli/util"
+)
+
+func TestMinerUpdateSettings(t *testing.T) {
+	t.Parallel()
+
+	if _, err := os.Stat("./config/" + minerNodeDelegateWallet + "_wallet.json"); err != nil {
+		t.Skipf("blobber owner wallet located at %s is missing", "./config/"+minerNodeDelegateWallet+"_wallet.json")
+	}
+}
+
+func minerUpdateSettings(t *testing.T, cliConfigFilename, params string) ([]string, error) {
+	return minerUpdateSettingsForWallet(t, cliConfigFilename, params, minerNodeDelegateWallet)
+}
+
+func minerUpdateSettingsForWallet(t *testing.T, cliConfigFilename, params, wallet string) ([]string, error) {
+	t.Log("Updating miner settings...")
+	return cliutils.RunCommand(t, fmt.Sprintf("./zbox mn-update-settings %s --silent --wallet %s_wallet.json --configDir ./config --config %s", params, wallet, cliConfigFilename), 3, time.Second*2)
+}

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -222,6 +222,15 @@ func TestMinerUpdateSettings(t *testing.T) {
 		require.Len(t, output, 1)
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})
+
+	t.Run("Miner update without miner id flag should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := minerUpdateSettings(t, configPath, "", false)
+		require.NotNil(t, err, "expected error trying to update miner node settings without id, but got output:", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "missing id flag", output[0])
+	})
 }
 
 func listMiners(t *testing.T, cliConfigFilename, params string) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -256,19 +256,50 @@ func TestMinerUpdateSettings(t *testing.T) {
 		miner := miners.Nodes[2]
 
 		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
-			"id": miner.ID,
+			"id":        miner.ID,
 			"max_stake": -1,
 		}), false)
-		defer func ()  {
+		defer func() {
 			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
-				"id": miner.ID,
+				"id":        miner.ID,
 				"max_stake": miner.MaxStake / 1e10, //miner.MaxStake is in Int, but this command takes params in ZCN
-			}), true)	
+			}), true)
 			require.Nil(t, err, "error reverting miner node settings after test")
 			require.Len(t, output, 1)
 			require.Equal(t, "settings updated", output[0])
 		}()
 		require.NotNil(t, err, "expected error negative max_stake but got output:", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+	})
+
+	t.Run("Miner update num_delegate negative value should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := listMiners(t, configPath, "--json")
+		require.Nil(t, err, "error listing miners")
+		require.Len(t, output, 1)
+
+		var miners climodel.MinerSCNodes
+		err = json.Unmarshal([]byte(output[0]), &miners)
+		require.Nil(t, err, "error unmarshalling ls-miners json output")
+
+		miner := miners.Nodes[2]
+
+		output, err = minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":            miner.ID,
+			"num_delegates": -1,
+		}), false)
+		defer func() {
+			output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+				"id":            miner.ID,
+				"num_delegates": miner.NumberOfDelegates,
+			}), true)
+			require.Nil(t, err, "error reverting miner node settings after test")
+			require.Len(t, output, 1)
+			require.Equal(t, "settings updated", output[0])
+		}()
+		require.NotNil(t, err, "expected error on negative num_delegates but got output:", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -231,6 +231,18 @@ func TestMinerUpdateSettings(t *testing.T) {
 		require.Len(t, output, 1)
 		require.Equal(t, "missing id flag", output[0])
 	})
+
+	t.Run("Miner update with nothing to update should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := minerUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id": miner.ID,
+		}), false)
+		require.Nil(t, err, "output")
+		// FIXME: some indication that no param has been selected to update should be given
+		require.Len(t, output, 1)
+		require.Equal(t, "settings updated", output[0])
+	})
 }
 
 func listMiners(t *testing.T, cliConfigFilename, params string) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -243,6 +243,37 @@ func TestMinerUpdateSettings(t *testing.T) {
 		require.Len(t, output, 1)
 		require.Equal(t, "settings updated", output[0])
 	})
+
+	t.Run("Miner update settings from non-delegate wallet should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "error registering wallet", strings.Join(output, "\n"))
+
+		output, err = minerUpdateSettingsForWallet(t, configPath, createParams(map[string]interface{}{
+			"id":            miner.ID,
+			"num_delegates": 5,
+		}), escapedTestName(t), false)
+		require.NotNil(t, err, "expected error when updating miner settings from non delegate wallet", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+
+		output, err = minerUpdateSettingsForWallet(t, configPath, createParams(map[string]interface{}{
+			"id":        miner.ID,
+			"min_stake": 1,
+		}), escapedTestName(t), false)
+		require.NotNil(t, err, "expected error when updating miner settings from non delegate wallet", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+
+		output, err = minerUpdateSettingsForWallet(t, configPath, createParams(map[string]interface{}{
+			"id":        miner.ID,
+			"max_stake": 99,
+		}), escapedTestName(t), false)
+		require.NotNil(t, err, "expected error when updating miner settings from non delegate wallet", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+	})
 }
 
 func listMiners(t *testing.T, cliConfigFilename, params string) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_miner_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_miner_update_settings_test.go
@@ -57,9 +57,6 @@ func TestMinerUpdateSettings(t *testing.T) {
 			"id":        miner.ID,
 			"min_stake": 1,
 		}), true)
-		require.Nil(t, err, "error reverting miner node settings after test")
-		require.Len(t, output, 1)
-		require.Equal(t, "settings updated", output[0])
 
 		require.Nil(t, err, "error updating min stake in miner node")
 		require.Len(t, output, 1)

--- a/tests/cli_tests/zwalletcli_send_and_balance_test.go
+++ b/tests/cli_tests/zwalletcli_send_and_balance_test.go
@@ -380,8 +380,12 @@ func getNodeBalanceFromASharder(t *testing.T, client_id string) *apimodel.Balanc
 }
 
 func getShardersList(t *testing.T) map[string]climodel.Sharder {
+	return getShardersListForWallet(t, escapedTestName(t))
+}
+
+func getShardersListForWallet(t *testing.T, wallet string) map[string]climodel.Sharder {
 	// Get sharder list.
-	output, err := getSharders(t, configPath)
+	output, err := getShardersForWallet(t, configPath, wallet)
 	require.Nil(t, err, "get sharders failed", strings.Join(output, "\n"))
 	require.Greater(t, len(output), 1)
 	require.Equal(t, "MagicBlock Sharders", output[0])

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -226,6 +226,18 @@ func TestSharderUpdateSettings(t *testing.T) {
 		require.Len(t, output, 1)
 		require.Equal(t, "missing id flag", output[0])
 	})
+
+	t.Run("Sharder update with nothing to update should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id": sharder.ID,
+		}), false)
+		// FIXME: some indication that no param has been selected to update should be given
+		require.Nil(t, err)
+		require.Len(t, output, 1)
+		require.Equal(t, "settings updated", output[0])
+	})
 }
 
 func sharderUpdateSettings(t *testing.T, cliConfigFilename, params string, retry bool) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -169,6 +169,18 @@ func TestSharderUpdateSettings(t *testing.T) {
 		require.Len(t, output, 1)
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})
+
+	t.Run("Sharder update max_stake more than global max_stake should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":        sharder.ID,
+			"max_stake": mnConfig["max_stake"] - 1e-10, // FIXME: should be +
+		}), false)
+		require.NotNil(t, err, "expected error when updating max_store greater than max allowed but got output:", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+	})
 }
 
 func sharderUpdateSettings(t *testing.T, cliConfigFilename, params string, retry bool) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -181,6 +181,18 @@ func TestSharderUpdateSettings(t *testing.T) {
 		require.Len(t, output, 1)
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})
+
+	t.Run("Miner update min_stake negative value should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":        sharder.ID,
+			"min_stake": -1,
+		}), false)
+		require.NotNil(t, err, "expected error when updating negative min_stake but got ouput:", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+	})
 }
 
 func sharderUpdateSettings(t *testing.T, cliConfigFilename, params string, retry bool) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -217,6 +217,15 @@ func TestSharderUpdateSettings(t *testing.T) {
 		require.Len(t, output, 1)
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})
+
+	t.Run("Sharder update without sharder id flag should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := sharderUpdateSettings(t, configPath, "", false)
+		require.NotNil(t, err, "expected error trying to update sharder node without id, but got output:", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, "missing id flag", output[0])
+	})
 }
 
 func sharderUpdateSettings(t *testing.T, cliConfigFilename, params string, retry bool) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -1,0 +1,67 @@
+package cli_tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	climodel "github.com/0chain/system_test/internal/cli/model"
+	cliutils "github.com/0chain/system_test/internal/cli/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharderUpdateSettings(t *testing.T) {
+	t.Parallel()
+
+	if _, err := os.Stat("./config/" + sharderNodeDelegateWalletName + "_wallet.json"); err != nil {
+		t.Skipf("Sharder node owner wallet located at %s is missing", "./config/"+sharderNodeDelegateWalletName+"_wallet.json")
+	}
+
+	sharderNodeDelegateWallet, err := getWalletForName(t, configPath, sharderNodeDelegateWalletName)
+	require.Nil(t, err, "error fetching sharder wallet")
+
+	output, err := minerInfo(t, configPath, createParams(map[string]interface{}{
+		"id": sharderNodeDelegateWallet.ClientID,
+	}), true)
+	require.Nil(t, err, "error fetching sharder settings")
+	require.Len(t, output, 1)
+
+	var oldSharderInfo climodel.Node
+	err = json.Unmarshal([]byte(output[0]), &oldSharderInfo)
+	require.Nil(t, err, "error unmarhsalling mn-info json output")
+
+	sharders := getShardersListForWallet(t, sharderNodeDelegateWalletName)
+	var sharder climodel.Sharder
+	for _, sharder = range sharders {
+		if sharder.ID == sharderNodeDelegateWallet.ClientID {
+			break
+		}
+	}
+
+	defer func() {
+		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":            sharder.ID,
+			"num_delegates": oldSharderInfo.NumberOfDelegates,
+			"max_stake":     intToZCN(oldSharderInfo.MaxStake),
+			"min_stake":     intToZCN(oldSharderInfo.MinStake),
+		}), true)
+		require.Nil(t, err, "error reverting sharder settings after test")
+		require.Len(t, output, 1)
+		require.Equal(t, "settings updated", output[0])
+	}()
+}
+
+func sharderUpdateSettings(t *testing.T, cliConfigFilename, params string, retry bool) ([]string, error) {
+	return sharderUpdateSettingsForWallet(t, cliConfigFilename, params, sharderNodeDelegateWalletName, retry)
+}
+
+func sharderUpdateSettingsForWallet(t *testing.T, cliConfigFilename, params, wallet string, retry bool) ([]string, error) {
+	t.Logf("Updating Sharder node info...")
+	if retry {
+		return cliutils.RunCommand(t, fmt.Sprintf("./zwallet mn-update-node-settings %s --sharder --silent --wallet %s_wallet.json --configDir ./config --config %s", params, wallet, cliConfigFilename), 3, time.Second)
+	} else {
+		return cliutils.RunCommandWithoutRetry(fmt.Sprintf("./zwallet mn-update-node-settings %s --sharder --silent --wallet %s_wallet.json --configDir ./config --config %s", params, wallet, cliConfigFilename))
+	}
+}

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -205,6 +205,18 @@ func TestSharderUpdateSettings(t *testing.T) {
 		require.Len(t, output, 1)
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})
+
+	t.Run("Sharder update num_delegates negative value should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":            sharder.ID,
+			"num_delegates": -1,
+		}), false)
+		require.NotNil(t, err, "expected error when updating negative num_delegates but got output:", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+	})
 }
 
 func sharderUpdateSettings(t *testing.T, cliConfigFilename, params string, retry bool) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -182,14 +182,26 @@ func TestSharderUpdateSettings(t *testing.T) {
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})
 
-	t.Run("Miner update min_stake negative value should fail", func(t *testing.T) {
+	t.Run("Sharder update min_stake negative value should fail", func(t *testing.T) {
 		t.Parallel()
 
 		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
 			"id":        sharder.ID,
 			"min_stake": -1,
 		}), false)
-		require.NotNil(t, err, "expected error when updating negative min_stake but got ouput:", strings.Join(output, "\n"))
+		require.NotNil(t, err, "expected error when updating negative min_stake but got output:", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+	})
+
+	t.Run("Sharder update max_stake value should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":        sharder.ID,
+			"max_stake": -1,
+		}), false)
+		require.NotNil(t, err, "expected error when updating negative max_stake but got output:", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -238,6 +238,37 @@ func TestSharderUpdateSettings(t *testing.T) {
 		require.Len(t, output, 1)
 		require.Equal(t, "settings updated", output[0])
 	})
+
+	t.Run("Sharder update settings from non-delegate wallet should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := registerWallet(t, configPath)
+		require.Nil(t, err, "error registering wallet", strings.Join(output, "\n"))
+
+		output, err = sharderUpdateSettingsForWallet(t, configPath, createParams(map[string]interface{}{
+			"id":            sharder.ID,
+			"num_delegates": 5,
+		}), escapedTestName(t), false)
+		require.NotNil(t, err, "expected error when updating sharder settings from non delegate wallet", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+
+		output, err = sharderUpdateSettingsForWallet(t, configPath, createParams(map[string]interface{}{
+			"id":        sharder.ID,
+			"max_stake": 99,
+		}), escapedTestName(t), false)
+		require.NotNil(t, err, "expected error when updating sharder settings from non delegate wallet", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+
+		output, err = sharderUpdateSettingsForWallet(t, configPath, createParams(map[string]interface{}{
+			"id":        sharder.ID,
+			"min_stake": 1,
+		}), escapedTestName(t), false)
+		require.NotNil(t, err, "expected error when updating sharder settings from non delegate wallet", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+	})
 }
 
 func sharderUpdateSettings(t *testing.T, cliConfigFilename, params string, retry bool) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -51,6 +51,27 @@ func TestSharderUpdateSettings(t *testing.T) {
 		require.Len(t, output, 1)
 		require.Equal(t, "settings updated", output[0])
 	}()
+
+	t.Run("Sharder update min_stake by delegate wallet should work", func(t *testing.T) {
+		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":        sharder.ID,
+			"min_stake": 1,
+		}), true)
+		require.Nil(t, err, "error reverting sharder node settings after test")
+		require.Len(t, output, 1)
+		require.Equal(t, "settings updated", output[0])
+
+		output, err = minerInfo(t, configPath, createParams(map[string]interface{}{
+			"id": sharder.ID,
+		}), true)
+		require.Nil(t, err, "error fwtching sharder info")
+		require.Len(t, output, 1)
+
+		var sharderInfo climodel.Node
+		err = json.Unmarshal([]byte(output[0]), &sharderInfo)
+		require.Nil(t, err, "error unmarshalling sharder info")
+		require.Equal(t, 1, int(intToZCN(sharderInfo.MinStake)))
+	})
 }
 
 func sharderUpdateSettings(t *testing.T, cliConfigFilename, params string, retry bool) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -182,6 +182,19 @@ func TestSharderUpdateSettings(t *testing.T) {
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})
 
+	t.Run("Sharder update min_stake greater than max_stake should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":        sharder.ID,
+			"max_stake": 48,
+			"min_stake": 51,
+		}), false)
+		require.NotNil(t, err, "expected error when trying to update min_stake greater than max stake but got output:", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+	})
+
 	t.Run("Sharder update min_stake negative value should fail", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -68,7 +68,7 @@ func TestSharderUpdateSettings(t *testing.T) {
 		output, err = minerInfo(t, configPath, createParams(map[string]interface{}{
 			"id": sharder.ID,
 		}), true)
-		require.Nil(t, err, "error fwtching sharder info")
+		require.Nil(t, err, "error fetching sharder info")
 		require.Len(t, output, 1)
 
 		var sharderInfo climodel.Node

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -72,6 +72,27 @@ func TestSharderUpdateSettings(t *testing.T) {
 		require.Nil(t, err, "error unmarshalling sharder info")
 		require.Equal(t, 1, int(intToZCN(sharderInfo.MinStake)))
 	})
+
+	t.Run("Sharder update num_delegates by delegate wallet should work", func(t *testing.T) {
+		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id": sharder.ID, 
+			"num_delegates": 5,
+		}), true)
+		require.Nil(t, err, "error updating num_delegated in sharder node")
+		require.Len(t, output, 1)
+		require.Equal(t, "settings updated", output[0])
+
+		output, err = minerInfo(t, configPath, createParams(map[string]interface{}{
+			"id": sharder.ID,
+		}), true)
+		require.Nil(t, err, "error fetching sharder info")
+		require.Len(t, output, 1)
+
+		var sharderInfo climodel.Node
+		err = json.Unmarshal([]byte(output[0]), &sharderInfo)
+		require.Nil(t, err, "error unmarhsalling sharder node info")
+		require.Equal(t, 5, sharderInfo.NumberOfDelegates)
+	})
 }
 
 func sharderUpdateSettings(t *testing.T, cliConfigFilename, params string, retry bool) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -157,6 +157,18 @@ func TestSharderUpdateSettings(t *testing.T) {
 		require.Len(t, output, 1)
 		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
 	})
+
+	t.Run("Sharder update with num_delegates more than global max_delegates should fail", func(t *testing.T) {
+		t.Parallel()
+
+		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":            sharder.ID,
+			"num_delegates": mnConfig["max_delegates"] + 1,
+		}), false)
+		require.NotNil(t, err, "expected error when updating num_delegates greater than max allowed but got output:", strings.Join(output, "\n"))
+		require.Len(t, output, 1)
+		require.Equal(t, `fatal:{"error": "verify transaction failed"}`, output[0])
+	})
 }
 
 func sharderUpdateSettings(t *testing.T, cliConfigFilename, params string, retry bool) ([]string, error) {

--- a/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
+++ b/tests/cli_tests/zwalletcli_sharder_update_settings_test.go
@@ -75,7 +75,7 @@ func TestSharderUpdateSettings(t *testing.T) {
 
 	t.Run("Sharder update num_delegates by delegate wallet should work", func(t *testing.T) {
 		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
-			"id": sharder.ID, 
+			"id":            sharder.ID,
 			"num_delegates": 5,
 		}), true)
 		require.Nil(t, err, "error updating num_delegated in sharder node")
@@ -92,6 +92,27 @@ func TestSharderUpdateSettings(t *testing.T) {
 		err = json.Unmarshal([]byte(output[0]), &sharderInfo)
 		require.Nil(t, err, "error unmarhsalling sharder node info")
 		require.Equal(t, 5, sharderInfo.NumberOfDelegates)
+	})
+
+	t.Run("Sharder update max_stake by delegate wallet should work", func(t *testing.T) {
+		output, err := sharderUpdateSettings(t, configPath, createParams(map[string]interface{}{
+			"id":        sharder.ID,
+			"max_stake": 101, // FIXME: should be 99
+		}), true)
+		require.Nil(t, err, "error updating max_stake in sharder node")
+		require.Len(t, output, 1)
+		require.Equal(t, "settings updated", output[0])
+
+		output, err = minerInfo(t, configPath, createParams(map[string]interface{}{
+			"id": sharder.ID,
+		}), true)
+		require.Nil(t, err, "error fetching sharder info")
+		require.Len(t, output, 1)
+
+		var sharderInfo climodel.Node
+		err = json.Unmarshal([]byte(output[0]), &sharderInfo)
+		require.Nil(t, err, "error unmarshalling sharder info")
+		require.Equal(t, 101, int(intToZCN(sharderInfo.MaxStake)))
 	})
 }
 


### PR DESCRIPTION
Cases added:

Miner settings update:
- Miner update min_stake by delegate wallet should work
- Miner update num_delegates by delegate wallet should work
- Miner update max_stake with delegate wallet should work
- Miner update multiple settings with delegate wallet should work
- Miner update min_stake with less than global min stake should fail
- Miner update num_delegates greater than global max_delegates should fail
- Miner update max_stake greater than global max_stake should fail
- Miner update max_stake less than min_stake should fail
- Miner update min_stake negative value should fail
- Miner update max_stake negative value should fail
- Miner update num_delegate negative value should fail
- Miner update without miner id flag should fail
- Miner update with nothing to update should fail
- Miner update settings from non-delegate wallet should fail

Sharder settings update:
- Sharder update min_stake by delegate wallet should work
- Sharder update num_delegates by delegate wallet should work
- Sharder update max_stake by delegate wallet should work
- Sharder update multiple settings with delegate wallet should work
- Sharder update with min_stake less than global min should fail
- Sharder update with num_delegates more than global max_delegates should fail
- Sharder update max_stake more than global max_stake should fail
- Sharder update min_stake greater than max_stake should fail
- Sharder update min_stake negative value should fail
- Sharder update max_stake value should fail
- Sharder update num_delegates negative value should fail
- Sharder update without sharder id flag should fail
- Sharder update with nothing to update should fail
- Sharder update settings from non-delegate wallet should fail

Bug fixes:
- https://github.com/0chain/0chain/pull/856
- https://github.com/0chain/0chain/pull/861
- https://github.com/0chain/0chain/pull/869