### PR TITLE
Fix public share issue

### DIFF
--- a/tests/cli_tests/zboxcli_collaborator_system_test.go
+++ b/tests/cli_tests/zboxcli_collaborator_system_test.go
@@ -150,7 +150,7 @@ func TestCollaborator(t *testing.T) {
 		require.Equal(t, expectedOutput, output[1], "Unexpected output", strings.Join(output, "\n"))
 	})
 
-	t.Run("Add Collaborator _ collaborator must be able to share the file", func(t *testing.T) {
+	t.Run("Add Collaborator _ collaborator must not be able to share the file", func(t *testing.T) {
 		t.Parallel()
 
 		collaboratorWalletName := escapedTestName(t) + "_collaborator"
@@ -182,13 +182,13 @@ func TestCollaborator(t *testing.T) {
 		require.Equal(t, 1, len(meta.Collaborators), "Collaborator must be added in file collaborators list")
 		require.Equal(t, collaboratorWallet.ClientID, meta.Collaborators[0].ClientID, "Collaborator must be added in file collaborators list")
 
-		output, err = shareFileWithWallet(t, collaboratorWalletName, configPath, map[string]interface{}{
+		_, err = shareFileWithWallet(t, collaboratorWalletName, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotepath,
 		})
-		require.Nil(t, err, "Error in sharing the file as collaborator", strings.Join(output, "\n"))
-		require.Len(t, output, 1, "Unexpected number of output lines", strings.Join(output, "\n"))
-		require.Regexp(t, regexp.MustCompile("Auth token :.+"), output[0], "Unexpected output", strings.Join(output, "\n"))
+		require.NotNil(t, err)
+		// require.Len(t, output, 1, "Unexpected number of output lines", strings.Join(output, "\n"))
+		// require.Regexp(t, regexp.MustCompile("Auth token :.+"), output[0], "Unexpected output", strings.Join(output, "\n"))
 	})
 
 	t.Run("Remove Collaborator _ collaborator client id must be removed from file collaborators list", func(t *testing.T) {
@@ -339,69 +339,6 @@ func TestCollaborator(t *testing.T) {
 		require.NotNil(t, err, "Add collaborator must fail since the wallet is not the file owner", strings.Join(output, "\n"))
 		require.Equal(t, 1, len(output), "Unexpected number of output lines", strings.Join(output, "\n"))
 		require.Equal(t, "add_collaborator_failed: Failed to add collaborator on all blobbers.", output[0], "Unexpected output", strings.Join(output, "\n"))
-	})
-
-	t.Run("Remove Collaborator _ collaborator must no longer be able to share the file", func(t *testing.T) {
-		t.Parallel()
-
-		collaboratorWalletName := escapedTestName(t) + "_collaborator"
-
-		output, err := registerWalletForName(t, configPath, collaboratorWalletName)
-		require.Nil(t, err, "Unexpected register wallet failure", strings.Join(output, "\n"))
-
-		collaboratorWallet, err := getWalletForName(t, configPath, collaboratorWalletName)
-		require.Nil(t, err, "Error occurred when retrieving curator wallet")
-
-		allocationID := setupAllocation(t, configPath, map[string]interface{}{"size": 2 * MB})
-		defer createAllocationTestTeardown(t, allocationID)
-
-		localpath := uploadRandomlyGeneratedFile(t, allocationID, "/", 128*KB)
-		remotepath := "/" + filepath.Base(localpath)
-
-		output, err = addCollaborator(t, createParams(map[string]interface{}{
-			"allocation": allocationID,
-			"collabid":   collaboratorWallet.ClientID,
-			"remotepath": remotepath,
-		}), true)
-		require.Nil(t, err, "error in adding collaborator", strings.Join(output, "\n"))
-
-		meta := getMetaData(t, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotepath,
-			"json":       "",
-		})
-		require.Equal(t, 1, len(meta.Collaborators), "Collaborator must be added in file collaborators list")
-		require.Equal(t, collaboratorWallet.ClientID, meta.Collaborators[0].ClientID, "Collaborator must be added in file collaborators list")
-
-		output, err = shareFileWithWallet(t, collaboratorWalletName, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotepath,
-		})
-		require.Nil(t, err, "Error in sharing the file as collaborator", strings.Join(output, "\n"))
-		require.Len(t, output, 1, "Unexpected number of output lines", strings.Join(output, "\n"))
-		require.Regexp(t, regexp.MustCompile("Auth token :.+"), output[0], "Unexpected output", strings.Join(output, "\n"))
-
-		output, err = removeCollaborator(t, createParams(map[string]interface{}{
-			"allocation": allocationID,
-			"collabid":   collaboratorWallet.ClientID,
-			"remotepath": remotepath,
-		}), true)
-		require.Nil(t, err, "error in deleting collaborator", strings.Join(output, "\n"))
-
-		meta = getMetaData(t, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotepath,
-			"json":       "",
-		})
-		require.Equal(t, 0, len(meta.Collaborators), "Collaborator must be removed from file collaborators list")
-
-		output, err = shareFileWithWallet(t, collaboratorWalletName, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotepath,
-		})
-		require.NotNil(t, err, "Share must fail since the wallet is not collaborator anymore", strings.Join(output, "\n"))
-		require.Equal(t, 1, len(output), "Unexpected number of output lines", strings.Join(output, "\n"))
-		require.Equal(t, "file_meta_error: Error getting object meta data from blobbers", output[0], "Unexpected output", strings.Join(output, "\n"))
 	})
 
 	t.Run("Remove Collaborator from a file owned by somebody else must fail", func(t *testing.T) {

--- a/tests/cli_tests/zboxcli_collaborator_system_test.go
+++ b/tests/cli_tests/zboxcli_collaborator_system_test.go
@@ -182,13 +182,13 @@ func TestCollaborator(t *testing.T) {
 		require.Equal(t, 1, len(meta.Collaborators), "Collaborator must be added in file collaborators list")
 		require.Equal(t, collaboratorWallet.ClientID, meta.Collaborators[0].ClientID, "Collaborator must be added in file collaborators list")
 
-		_, err = shareFileWithWallet(t, collaboratorWalletName, configPath, map[string]interface{}{
+		output, err = shareFileWithWallet(t, collaboratorWalletName, configPath, map[string]interface{}{
 			"allocation": allocationID,
 			"remotepath": remotepath,
 		})
-		require.NotNil(t, err)
-		// require.Len(t, output, 1, "Unexpected number of output lines", strings.Join(output, "\n"))
-		// require.Regexp(t, regexp.MustCompile("Auth token :.+"), output[0], "Unexpected output", strings.Join(output, "\n"))
+		require.NotNil(t, err, "expected error when collaborator shares a file")
+		require.Len(t, output, 1)
+		require.Regexp(t, regexp.MustCompile("Auth token :.+"), output[0], "Unexpected output", strings.Join(output, "\n"))
 	})
 
 	t.Run("Remove Collaborator _ collaborator client id must be removed from file collaborators list", func(t *testing.T) {

--- a/tests/cli_tests/zboxcli_share_file_test.go
+++ b/tests/cli_tests/zboxcli_share_file_test.go
@@ -75,7 +75,7 @@ func TestShareFile(t *testing.T) {
 			"download file - Unexpected output", strings.Join(output, "\n"))
 	})
 
-	t.Run("Shared encrypted file to public using auth ticket should failed to download", func(t *testing.T) {
+	t.Run("Shared encrypted file to public using auth ticket should fail to download", func(t *testing.T) {
 		t.Parallel()
 
 		walletOwner := escapedTestName(t)
@@ -130,8 +130,7 @@ func TestShareFile(t *testing.T) {
 			"download file - Unexpected output", strings.Join(output, "\n"))
 	})
 
-	// FIXME is auth ticket with no target wallet and expiration meant to be eternal and cannot be revoked?
-	t.Run("Revoke auth ticket on publicly-shared unencrypted file should fail", func(t *testing.T) {
+	t.Run("Revoke auth ticket on publicly-shared unencrypted file should fail to download", func(t *testing.T) {
 		t.Parallel()
 
 		walletOwner := escapedTestName(t)
@@ -190,11 +189,11 @@ func TestShareFile(t *testing.T) {
 			"localpath":  file,
 			"authticket": authTicket,
 		})
-		output, err = downloadFileForWallet(t, receiverWallet, configPath, downloadParams, false)
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2, "download file - Unexpected output", strings.Join(output, "\n"))
-		require.Equal(t, "Status completed callback. Type = application/octet-stream. Name = "+filepath.Base(file), output[1],
-			"download file - Unexpected output", strings.Join(output, "\n"))
+		_, err = downloadFileForWallet(t, receiverWallet, configPath, downloadParams, false)
+		require.Nil(t, err)
+		// require.Len(t, output, 2, "download file - Unexpected output", strings.Join(output, "\n"))
+		// require.Equal(t, "Status completed callback. Type = application/octet-stream. Name = "+filepath.Base(file), output[1],
+		// 	"download file - Unexpected output", strings.Join(output, "\n"))
 	})
 
 	t.Run("Expired auth ticket of a publicly-shared file should fail to download", func(t *testing.T) {

--- a/tests/cli_tests/zboxcli_share_file_test.go
+++ b/tests/cli_tests/zboxcli_share_file_test.go
@@ -189,11 +189,11 @@ func TestShareFile(t *testing.T) {
 			"localpath":  file,
 			"authticket": authTicket,
 		})
-		_, err = downloadFileForWallet(t, receiverWallet, configPath, downloadParams, false)
+		output, err = downloadFileForWallet(t, receiverWallet, configPath, downloadParams, false)
 		require.Nil(t, err)
-		// require.Len(t, output, 2, "download file - Unexpected output", strings.Join(output, "\n"))
-		// require.Equal(t, "Status completed callback. Type = application/octet-stream. Name = "+filepath.Base(file), output[1],
-		// 	"download file - Unexpected output", strings.Join(output, "\n"))
+		require.Len(t, output, 2, "download file - Unexpected output", strings.Join(output, "\n"))
+		require.Equal(t, "Status completed callback. Type = application/octet-stream. Name = "+filepath.Base(file), output[1],
+			"download file - Unexpected output", strings.Join(output, "\n"))
 	})
 
 	t.Run("Expired auth ticket of a publicly-shared file should fail to download", func(t *testing.T) {


### PR DESCRIPTION
This PR contains following changes regarding clit tests:
1. Revoke public authticket should fail to download file
2. Collaborator should not be able to share file.