### PR TITLE
remove parallel

### DIFF
--- a/tests/cli_tests/zwalletcli_zcnbridge_ethereum-account-register_test.go
+++ b/tests/cli_tests/zwalletcli_zcnbridge_ethereum-account-register_test.go
@@ -28,8 +28,6 @@ func TestEthRegisterAccount(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Register ethereum account in local key storage", func(t *testing.T) {
-		t.Parallel()
-
 		deleteDefaultAccountInStorage(t, address)
 		output, err := importAccount(t, mnemonic, password, false)
 		require.Nil(t, err, "error trying to register ethereum account", strings.Join(output, "\n"))
@@ -37,8 +35,6 @@ func TestEthRegisterAccount(t *testing.T) {
 	})
 
 	t.Run("List ethereum account registered in local key storage", func(t *testing.T) {
-		t.Parallel()
-
 		deleteDefaultAccountInStorage(t, address)
 		output, err := importAccount(t, password, mnemonic, false)
 		require.NoError(t, err, strings.Join(output, "\n"))


### PR DESCRIPTION
Removing parallel running of these cases because:
- They are very small tests 
![image](https://user-images.githubusercontent.com/42718091/153062608-4b97347d-8a5e-4f8f-9ee0-642963f4ac36.png)
- Since there is shared data (account based on same mnemonic) I suspect running in parallel is introducing flakiness (see [here](https://github.com/0chain/blobber/runs/5114094520?check_suite_focus=true) and [here](https://github.com/0chain/blobber/actions/runs/1810379214/attempts/1))