### PR TITLE
Match test against new zwallet-cli pre-run check

### DIFF
--- a/tests/cli_tests/zwalletcli_multisig_wallet_test.go
+++ b/tests/cli_tests/zwalletcli_multisig_wallet_test.go
@@ -114,8 +114,6 @@ func TestMultisigWallet(t *testing.T) {
 			"--config %s", 3, escapedTestName(t)+"_wallet.json", configPath))
 
 		require.NotNil(t, err, "expected command to fail", strings.Join(output, "\n"))
-		require.True(t, len(output) > 4, "Output was less than number "+
-			"of assertions", strings.Join(output, "\n"))
 
 		require.Contains(t, output, "Error: threshold flag is missing")
 	})


### PR DESCRIPTION
Fix to go along zwallet-cli [PR #94](https://github.com/0chain/zwalletcli/pull/94), which moves the check for an wallet config file to a pre-run hook, instead of being run on initialization.