### PR TITLE
re-add len check

### DIFF
--- a/tests/cli_tests/zwalletcli_multisig_wallet_test.go
+++ b/tests/cli_tests/zwalletcli_multisig_wallet_test.go
@@ -114,8 +114,8 @@ func TestMultisigWallet(t *testing.T) {
 			"--config %s", 3, escapedTestName(t)+"_wallet.json", configPath))
 
 		require.NotNil(t, err, "expected command to fail", strings.Join(output, "\n"))
-
-		require.Contains(t, output, "Error: threshold flag is missing")
+		require.Len(t, output, 1)
+		require.Equal(t, "Error: threshold flag is missing", output[0])
 	})
 }
 


### PR DESCRIPTION
- Len check from `TestMultisigWallet` was recently removed in this [PR](https://github.com/0chain/system_test/pull/207). This patches it.