### PR TITLE
fix(wallet): fixed recoverwallet tests

### DIFF
--- a/tests/cli_tests/zwalletcli_recover_wallet_test.go
+++ b/tests/cli_tests/zwalletcli_recover_wallet_test.go
@@ -36,14 +36,9 @@ func TestRecoverWallet(t *testing.T) {
 		output, err := recoverWalletFromMnemonic(t, configPath, inValidMnemonic, false)
 
 		require.NotNil(t, err, "expected error to occur recovering a wallet", strings.Join(output, "\n"))
-		require.Len(t, output, 5)
-		require.Equal(t, "No wallet in path"+
-			"  ./config/TestRecoverWallet-Recover_wallet_invalid_mnemonic_wallet.json found."+
-			" Creating wallet...", output[0])
-		require.Equal(t, "ZCN wallet created!!", output[1])
-		require.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
-		require.Equal(t, "Read pool created successfully", output[3])
-		require.Equal(t, "Error: Invalid mnemonic", output[4])
+		require.Len(t, output, 1)
+
+		require.Equal(t, "Error: Invalid mnemonic", output[0])
 	})
 
 	t.Run("Recover wallet no mnemonic", func(t *testing.T) {
@@ -54,11 +49,7 @@ func TestRecoverWallet(t *testing.T) {
 			"--configDir ./config --config " + configPath)
 
 		require.NotNil(t, err, "expected error to occur recovering a wallet", strings.Join(output, "\n"))
-		require.Len(t, output, 5)
-		require.Equal(t, "No wallet in path  ./config/TestRecoverWallet-Recover_wallet_no_mnemonic_wallet.json found. Creating wallet...", output[0])
-		require.Equal(t, "ZCN wallet created!!", output[1])
-		require.Equal(t, "Creating related read pool for storage smart-contract...", output[2])
-		require.Equal(t, "Read pool created successfully", output[3])
+		require.Len(t, output, 1)
 		require.Equal(t, "Error: Mnemonic not provided", output[4])
 	})
 }

--- a/tests/cli_tests/zwalletcli_recover_wallet_test.go
+++ b/tests/cli_tests/zwalletcli_recover_wallet_test.go
@@ -22,7 +22,7 @@ func TestRecoverWallet(t *testing.T) {
 		output, err := recoverWalletFromMnemonic(t, configPath, validMnemonic, true)
 
 		require.Nil(t, err, "error occurred recovering a wallet", strings.Join(output, "\n"))
-		require.Len(t, output, 5)
+		require.Len(t, output, 1)
 		require.Equal(t, "Wallet recovered!!", output[len(output)-1])
 	})
 

--- a/tests/cli_tests/zwalletcli_recover_wallet_test.go
+++ b/tests/cli_tests/zwalletcli_recover_wallet_test.go
@@ -50,7 +50,7 @@ func TestRecoverWallet(t *testing.T) {
 
 		require.NotNil(t, err, "expected error to occur recovering a wallet", strings.Join(output, "\n"))
 		require.Len(t, output, 1)
-		require.Equal(t, "Error: Mnemonic not provided", output[4])
+		require.Equal(t, "Error: Mnemonic not provided", output[0])
 	})
 }
 


### PR DESCRIPTION
## Changes
- added `offline` support on command. 

## Fixes
- fixed `version` as `offline` command https://github.com/0chain/zwalletcli/issues/106
- added `--offline` on `createmswallet` and  `recoverwallet`
## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/zwalletcli/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- gosdk: https://github.com/0chain/gosdk/pull/481
- system_test: https://github.com/0chain/system_test/pull/291
- zwallet: https://github.com/0chain/zwalletcli/pull/131