### PR TITLE
Transfer allocation fix

### DIFF
--- a/tests/cli_tests/config/zbox_config.yaml
+++ b/tests/cli_tests/config/zbox_config.yaml
@@ -1,4 +1,4 @@
-block_worker: https://dev.0chain.net/dns
+block_worker: https://dev-1.devnet-0chain.net/dns
 signature_scheme: bls0chain
 min_submit: 50 # in percentage
 min_confirmation: 50 # in percentage

--- a/tests/cli_tests/zboxcli_transfer_allocation_test.go
+++ b/tests/cli_tests/zboxcli_transfer_allocation_test.go
@@ -64,38 +64,13 @@ func TestTransferAllocation(t *testing.T) { // nolint:gocyclo // team preference
 			"size": int64(1024000),
 		})
 
-		ownerWallet, err := getWallet(t, configPath)
-		require.Nil(t, err, "Error occurred when retrieving owner wallet")
-
-		output, err := addCurator(t, createParams(map[string]interface{}{
-			"allocation": allocationID,
-			"curator":    ownerWallet.ClientID,
-		}), true)
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 1, "add curator - Unexpected output", strings.Join(output, "\n"))
-		require.Equal(t, fmt.Sprintf("%s added %s as a curator to allocation %s", ownerWallet.ClientID, ownerWallet.ClientID, allocationID), output[0],
-			"add curator - Unexpected output", strings.Join(output, "\n"))
-
 		file := generateRandomTestFileName(t)
-		err = createFileWithSize(file, 204800)
+		err := createFileWithSize(file, 204800)
 		require.Nil(t, err)
-
-		filename := filepath.Base(file)
-		remotePath := "/child/" + filename
-
-		output, err = uploadFile(t, configPath, map[string]interface{}{
-			"allocation": allocationID,
-			"remotepath": remotePath,
-			"localpath":  file,
-		}, true)
-		require.Nil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 2, "upload file - Unexpected output", strings.Join(output, "\n"))
-		require.Equal(t, "Status completed callback. Type = application/octet-stream. Name = "+filepath.Base(file), output[1],
-			"upload file - Unexpected output", strings.Join(output, "\n"))
 
 		newOwner := escapedTestName(t) + "_NEW_OWNER"
 
-		output, err = registerWalletForName(t, configPath, newOwner)
+		output, err := registerWalletForName(t, configPath, newOwner)
 		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
 		output, err = executeFaucetWithTokensForWallet(t, newOwner, configPath, 1)

--- a/tests/cli_tests/zboxcli_transfer_allocation_test.go
+++ b/tests/cli_tests/zboxcli_transfer_allocation_test.go
@@ -20,43 +20,43 @@ import (
 func TestTransferAllocation(t *testing.T) { // nolint:gocyclo // team preference is to have codes all within test.
 	t.Parallel()
 
-	// t.Run("transfer allocation by curator should work", func(t *testing.T) {
-	// 	t.Parallel()
+	t.Run("transfer allocation by curator should work", func(t *testing.T) {
+		t.Parallel()
 
-	// 	allocationID := setupAllocation(t, configPath, map[string]interface{}{
-	// 		"size": int64(2048),
-	// 	})
+		allocationID := setupAllocation(t, configPath, map[string]interface{}{
+			"size": int64(2048),
+		})
 
-	// 	ownerWallet, err := getWallet(t, configPath)
-	// 	require.Nil(t, err, "Error occurred when retrieving owner wallet")
+		ownerWallet, err := getWallet(t, configPath)
+		require.Nil(t, err, "Error occurred when retrieving owner wallet")
 
-	// 	output, err := addCurator(t, createParams(map[string]interface{}{
-	// 		"allocation": allocationID,
-	// 		"curator":    ownerWallet.ClientID,
-	// 	}), true)
-	// 	require.Nil(t, err, strings.Join(output, "\n"))
-	// 	require.Len(t, output, 1, "add curator - Unexpected output", strings.Join(output, "\n"))
-	// 	require.Equal(t, fmt.Sprintf("%s added %s as a curator to allocation %s", ownerWallet.ClientID, ownerWallet.ClientID, allocationID), output[0],
-	// 		"add curator - Unexpected output", strings.Join(output, "\n"))
+		output, err := addCurator(t, createParams(map[string]interface{}{
+			"allocation": allocationID,
+			"curator":    ownerWallet.ClientID,
+		}), true)
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1, "add curator - Unexpected output", strings.Join(output, "\n"))
+		require.Equal(t, fmt.Sprintf("%s added %s as a curator to allocation %s", ownerWallet.ClientID, ownerWallet.ClientID, allocationID), output[0],
+			"add curator - Unexpected output", strings.Join(output, "\n"))
 
-	// 	newOwner := escapedTestName(t) + "_NEW_OWNER"
+		newOwner := escapedTestName(t) + "_NEW_OWNER"
 
-	// 	output, err = registerWalletForName(t, configPath, newOwner)
-	// 	require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
+		output, err = registerWalletForName(t, configPath, newOwner)
+		require.Nil(t, err, "registering wallet failed", strings.Join(output, "\n"))
 
-	// 	newOwnerWallet, err := getWalletForName(t, configPath, newOwner)
-	// 	require.Nil(t, err, "Error occurred when retrieving new owner wallet")
+		newOwnerWallet, err := getWalletForName(t, configPath, newOwner)
+		require.Nil(t, err, "Error occurred when retrieving new owner wallet")
 
-	// 	output, err = transferAllocationOwnership(t, map[string]interface{}{
-	// 		"allocation":    allocationID,
-	// 		"new_owner_key": newOwnerWallet.ClientPublicKey,
-	// 		"new_owner":     newOwnerWallet.ClientID,
-	// 	}, true)
-	// 	require.Nil(t, err, strings.Join(output, "\n"))
-	// 	require.Len(t, output, 1, "transfer allocation - Unexpected output", strings.Join(output, "\n"))
-	// 	require.Equal(t, fmt.Sprintf("transferred ownership of allocation %s to %s", allocationID, newOwnerWallet.ClientID), output[0],
-	// 		"transfer allocation - Unexpected output", strings.Join(output, "\n"))
-	// })
+		output, err = transferAllocationOwnership(t, map[string]interface{}{
+			"allocation":    allocationID,
+			"new_owner_key": newOwnerWallet.ClientPublicKey,
+			"new_owner":     newOwnerWallet.ClientID,
+		}, true)
+		require.Nil(t, err, strings.Join(output, "\n"))
+		require.Len(t, output, 1, "transfer allocation - Unexpected output", strings.Join(output, "\n"))
+		require.Equal(t, fmt.Sprintf("transferred ownership of allocation %s to %s", allocationID, newOwnerWallet.ClientID), output[0],
+			"transfer allocation - Unexpected output", strings.Join(output, "\n"))
+	})
 
 	t.Run("transfer allocation accounting test", func(t *testing.T) {
 		t.Parallel()
@@ -135,7 +135,7 @@ func TestTransferAllocation(t *testing.T) { // nolint:gocyclo // team preference
 			"get balance - Unexpected output", strings.Join(output, "\n"))
 
 		// Get expected upload cost
-		output, _ = getUploadCostInUnit(t, configPath, allocationID, filename)
+		output, _ = getUploadCostInUnit(t, configPath, allocationID, file)
 
 		expectedUploadCostInZCN, err := strconv.ParseFloat(strings.Fields(output[0])[0], 64)
 		require.Nil(t, err, "Cost couldn't be parsed to float", strings.Join(output, "\n"))
@@ -169,7 +169,7 @@ func TestTransferAllocation(t *testing.T) { // nolint:gocyclo // team preference
 		require.Equal(t, allocationID, finalWritePool[0].Id, strings.Join(output, "\n"))
 		require.Equal(t, allocationID, finalWritePool[0].AllocationId, strings.Join(output, "\n"))
 	})
-	return
+
 	t.Run("transfer allocation by owner should work", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/cli_tests/zboxcli_transfer_allocation_test.go
+++ b/tests/cli_tests/zboxcli_transfer_allocation_test.go
@@ -163,6 +163,7 @@ func TestTransferAllocation(t *testing.T) { // nolint:gocyclo // team preference
 
 		actualCost := initialWritePool[0].Balance - finalWritePool[0].Balance
 
+		// If a challenge has passed for upload, writepool balance should reduce, else, remain same
 		require.True(t, actualCost == 0 || intToZCN(actualCost) == actualExpectedUploadCostInZCN)
 		require.True(t, finalWritePool[0].Locked, strings.Join(output, "\n"))
 		require.Equal(t, allocationID, finalWritePool[0].Id, strings.Join(output, "\n"))


### PR DESCRIPTION
- The test asserts that writepool balance does not change after transferring allocation. As such, I don't see the need to upload a file before transferring allocation to test this. This PR corrects the test flow.