### PR TITLE
Get miner/sharder stats API tests

### DIFF
--- a/internal/api/model/model.go
+++ b/internal/api/model/model.go
@@ -292,6 +292,27 @@ type BCChallengeResponse struct {
 	Challenges []*ChallengeEntity `json:"challenges"`
 }
 
+type MinerStats struct {
+	BlockFinality      float64                  `json:"block_finality"`
+	LastFinalizedRound int64                    `json:"last_finalized_round"`
+	BlocksFinalized    int64                    `json:"blocks_finalized"`
+	StateHealth        int64                    `json:"state_health"`
+	CurrentRound       int64                    `json:"current_round"`
+	RoundTimeout       int64                    `json:"round_timeout"`
+	Timeouts           int64                    `json:"timeouts"`
+	AverageBlockSize   int                      `json:"average_block_size"`
+	NetworkTime        map[string]time.Duration `json:"network_times"`
+}
+
+type SharderStats struct {
+	LastFinalizedRound     int64   `json:"last_finalized_round"`
+	StateHealth            int64   `json:"state_health"`
+	AverageBlockSize       int     `json:"average_block_size"`
+	PrevInvocationCount    uint64  `json:"pervious_invocation_count"`
+	PrevInvocationScanTime string  `json:"previous_incovcation_scan_time"`
+	MeanScanBlockStatsTime float64 `json:"mean_scan_block_stats_time"`
+}
+
 func (w Wallet) String() string {
 	out, err := json.Marshal(w)
 	if err != nil {

--- a/internal/api/util/constants.go
+++ b/internal/api/util/constants.go
@@ -1,0 +1,3 @@
+package util
+
+const HttpOkStatus = "200 OK"

--- a/internal/api/util/zerochain.go
+++ b/internal/api/util/zerochain.go
@@ -39,18 +39,31 @@ func (z *Zerochain) Init(config Config) {
 	z.Sharders = healthySharders
 }
 
-func (z *Zerochain) GetFromMiners(t *testing.T, endpoint string, consensusMet ConsensusMetFunction) (*resty.Response, error) { //nolint
+func (z *Zerochain) GetFromMiners(t *testing.T, endpoint string, consensusMet ConsensusMetFunction, targetObject interface{}) (*resty.Response, error) { //nolint
 	getFromMiner := func(miner string) (*resty.Response, error) {
-		return z.GetFromMiner(t, miner, endpoint)
+		return z.GetFromMiner(t, miner, endpoint, targetObject)
 	}
-	return z.executeWithConsensus(t, z.Miners, getFromMiner, nil, consensusMet)
+	return z.executeWithConsensus(t, z.Miners, getFromMiner, targetObject, consensusMet)
 }
 
-func (z *Zerochain) GetFromMiner(t *testing.T, miner, endpoint string) (*resty.Response, error) { //nolint
+func (z *Zerochain) GetFromMiner(t *testing.T, miner, endpoint string, targetObject interface{}) (*resty.Response, error) { //nolint
 	resp, err := z.restClient.R().Get(miner + endpoint)
-	t.Logf("GET on miner [" + miner + "] endpoint  [" + endpoint + "] resulted in HTTP [" + resp.Status() + "] with body [" + resp.String() + "]")
+	if resp != nil && resp.IsError() {
+		t.Logf("GET on miner [" + miner + "] endpoint [" + endpoint + "] was unsuccessful, resulting in HTTP [" + resp.Status() + "] and body [" + resp.String() + "]")
+		return resp, nil
+	} else if err != nil {
+		t.Logf("GET on miner [" + miner + "] endpoint [" + endpoint + "] processed with error [" + err.Error() + "]")
+		return resp, err
+	} else {
+		t.Logf("GET on miner [" + miner + "] endpoint [" + endpoint + "] processed without error, resulting in HTTP [" + resp.Status() + "] with body [" + resp.String() + "]")
+		unmarshalError := json.Unmarshal(resp.Body(), targetObject)
 
-	return resp, err
+		if unmarshalError != nil {
+			return resp, unmarshalError
+		}
+
+		return resp, nil
+	}
 }
 
 func (z *Zerochain) PostToMiners(t *testing.T, endpoint string, consensusMet ConsensusMetFunction, body interface{}, targetObject interface{}) (*resty.Response, error) { //nolint

--- a/tests/api_tests/create_allocation_test.go
+++ b/tests/api_tests/create_allocation_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-resty/resty/v2" //nolint
 
 	"github.com/0chain/system_test/internal/api/model"
+	"github.com/0chain/system_test/internal/api/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,7 +58,7 @@ func getAllocation(t *testing.T, allocationId string) *model.Allocation {
 
 	require.NotNil(t, allocation, "Allocation was unexpectedly nil! with http response [%s]", httpResponse)
 	require.Nil(t, err, "Unexpected error [%s] occurred getting balance with http response [%s]", err, httpResponse)
-	require.Equal(t, "200 OK", httpResponse.Status())
+	require.Equal(t, util.HttpOkStatus, httpResponse.Status())
 
 	return allocation
 }

--- a/tests/api_tests/endpoints_test.go
+++ b/tests/api_tests/endpoints_test.go
@@ -63,3 +63,19 @@ func v1ScrestOpenChallenges(t *testing.T, storageSmartContractAddress string, bl
 	httpResponse, httpError := zeroChain.GetFromSharders(t, "/v1/screst/"+storageSmartContractAddress+"/openchallenges?blobber="+blobberId, consensusCategoriser, nil)
 	return httpResponse, httpError
 }
+
+func v1MinerGetStats(t *testing.T, consensusCategoriser util.ConsensusMetFunction) (*model.MinerStats, *resty.Response, error) { //nolint
+	var stats *model.MinerStats
+
+	httpResponse, httpError := zeroChain.GetFromMiners(t, "/v1/miner/get/stats", consensusCategoriser, &stats)
+
+	return stats, httpResponse, httpError
+}
+
+func v1SharderGetStats(t *testing.T, consensusCategoriser util.ConsensusMetFunction) (*model.SharderStats, *resty.Response, error) { //nolint
+	var stats *model.SharderStats
+
+	httpResponse, httpError := zeroChain.GetFromSharders(t, "/v1/sharder/get/stats", consensusCategoriser, &stats)
+
+	return stats, httpResponse, httpError
+}

--- a/tests/api_tests/execute_faucet_test.go
+++ b/tests/api_tests/execute_faucet_test.go
@@ -1,7 +1,6 @@
 package api_tests
 
 import (
-	"encoding/json"
 	resty "github.com/go-resty/resty/v2"
 	"testing"
 	"time"
@@ -37,7 +36,7 @@ func confirmTransaction(t *testing.T, wallet *model.Wallet, sentTransaction mode
 
 	require.NotNil(t, confirmation, "Confirmation was unexpectedly nil! with http response [%s]", httpResponse)
 	require.Nil(t, err, "Unexpected error [%s] occurred confirming transaction with http response [%s]", err, httpResponse)
-	require.Equal(t, "200 OK", httpResponse.Status())
+	require.Equal(t, util.HttpOkStatus, httpResponse.Status())
 	require.Equal(t, "1.0", confirmation.Version, "version did not match expected")
 	require.Equal(t, sentTransaction.Hash, confirmation.Hash, "hash did not match expected")
 	require.NotNil(t, confirmation.BlockHash)
@@ -81,7 +80,7 @@ func getBalance(t *testing.T, clientId string) *model.Balance {
 
 	require.NotNil(t, balance, "Balance was unexpectedly nil! with http response [%s]", httpResponse)
 	require.Nil(t, err, "Unexpected error [%s] occurred getting balance with http response [%s]", err, httpResponse)
-	require.Equal(t, "200 OK", httpResponse.Status())
+	require.Equal(t, util.HttpOkStatus, httpResponse.Status())
 
 	return balance
 }
@@ -94,8 +93,7 @@ func getBalanceWithoutAssertion(t *testing.T, clientId string) (*model.Balance, 
 
 func executeFaucet(t *testing.T, wallet *model.Wallet, keyPair model.KeyPair) *model.TransactionResponse {
 	t.Logf("Executing faucet...")
-	_, err := json.Marshal(model.SmartContractTxnData{Name: "pour"})
-	require.Nil(t, err)
+
 	faucetRequest := model.Transaction{
 		PublicKey:        keyPair.PublicKey.SerializeToHexStr(),
 		TxnOutputHash:    "",
@@ -120,7 +118,7 @@ func executeTransaction(t *testing.T, txnRequest *model.Transaction, keyPair mod
 
 	require.Nil(t, err, "Unexpected error [%s] occurred registering wallet with http response [%s]", err, httpResponse)
 	require.NotNil(t, transactionResponse, "Registered wallet was unexpectedly nil! with http response [%s]", httpResponse)
-	require.Equal(t, "200 OK", httpResponse.Status())
+	require.Equal(t, util.HttpOkStatus, httpResponse.Status())
 	require.True(t, transactionResponse.Async)
 	require.NotNil(t, transactionResponse.Entity, "Transaction entity was unexpectedly nil! with http response [%s]", httpResponse)
 	require.NotNil(t, transactionResponse.Entity.ChainId)

--- a/tests/api_tests/execute_faucet_test.go
+++ b/tests/api_tests/execute_faucet_test.go
@@ -3,7 +3,6 @@ package api_tests
 import (
 	"encoding/json"
 	resty "github.com/go-resty/resty/v2"
-	"strconv"
 	"testing"
 	"time"
 
@@ -95,7 +94,7 @@ func getBalanceWithoutAssertion(t *testing.T, clientId string) (*model.Balance, 
 
 func executeFaucet(t *testing.T, wallet *model.Wallet, keyPair model.KeyPair) *model.TransactionResponse {
 	t.Logf("Executing faucet...")
-	txnDataString, err := json.Marshal(model.SmartContractTxnData{Name: "pour"})
+	_, err := json.Marshal(model.SmartContractTxnData{Name: "pour"})
 	require.Nil(t, err)
 	faucetRequest := model.Transaction{
 		PublicKey:        keyPair.PublicKey.SerializeToHexStr(),
@@ -110,10 +109,6 @@ func executeFaucet(t *testing.T, wallet *model.Wallet, keyPair model.KeyPair) *m
 		Version:          "1.0",
 		TransactionNonce: wallet.Nonce + 1,
 	}
-
-	println(string(txnDataString))
-	println(strconv.Quote(string(txnDataString)))
-
 	faucetTransaction := executeTransaction(t, &faucetRequest, keyPair)
 	confirmTransaction(t, wallet, faucetTransaction.Entity, 1*time.Minute)
 

--- a/tests/api_tests/flaky___broken_scenarios_test.go
+++ b/tests/api_tests/flaky___broken_scenarios_test.go
@@ -29,11 +29,11 @@ func Test___BrokenScenariosRegisterWallet(t *testing.T) {
 
 		walletRequest := model.Wallet{Id: expectedClientId, PublicKey: expectedKeyPair.PublicKey.SerializeToHexStr(), CreationDate: &invalidCreationDate}
 
-		registeredWallet, httpResponse, err := v1ClientPut(t, walletRequest, util.ConsensusByHttpStatus("200 OK"))
+		registeredWallet, httpResponse, err := v1ClientPut(t, walletRequest, util.ConsensusByHttpStatus(util.HttpOkStatus))
 
 		require.Nil(t, err, "Unexpected error [%s] occurred registering wallet with http response [%s]", err, httpResponse)
 		require.NotNil(t, registeredWallet, "Registered wallet was unexpectedly nil! with http response [%s]", httpResponse)
-		require.Equal(t, "200 OK", httpResponse.Status())
+		require.Equal(t, util.HttpOkStatus, httpResponse.Status())
 		require.Equal(t, registeredWallet.Id, expectedClientId)
 		require.Equal(t, registeredWallet.PublicKey, expectedKeyPair.PublicKey.SerializeToHexStr())
 		require.Greater(t, *registeredWallet.CreationDate, 0, "Creation date is an invalid value!")

--- a/tests/api_tests/get_blobbers_for_new_allocation_test.go
+++ b/tests/api_tests/get_blobbers_for_new_allocation_test.go
@@ -2,6 +2,7 @@ package api_tests
 
 import (
 	"encoding/json"
+	"github.com/0chain/system_test/internal/api/util"
 	"testing"
 	"time"
 
@@ -39,7 +40,7 @@ func getBlobbersMatchingRequirements(t *testing.T, wallet *model.Wallet, keyPair
 
 	require.NotNil(t, blobbers, "Allocation was unexpectedly nil! with http response [%s]", httpResponse)
 	require.Nil(t, err, "Unexpected error [%s] occurred getting balance with http response [%s]", err, httpResponse)
-	require.Equal(t, "200 OK", httpResponse.Status())
+	require.Equal(t, util.HttpOkStatus, httpResponse.Status())
 
 	return blobbers, blobberRequirements
 }

--- a/tests/api_tests/get_stats_test.go
+++ b/tests/api_tests/get_stats_test.go
@@ -1,0 +1,44 @@
+package api_tests
+
+import (
+	"github.com/0chain/system_test/internal/api/util"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGetStats(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Get miner stats call should return successfully", func(t *testing.T) {
+		t.Parallel()
+		stats, httpResponse, err := v1MinerGetStats(t, util.ConsensusByHttpStatus("200 OK"))
+
+		require.Nil(t, err)
+		require.Equal(t, "200 OK", httpResponse.Status(), httpResponse)
+		require.NotNil(t, stats)
+		require.Greater(t, stats.BlockFinality, float64(0), httpResponse)
+		require.Greater(t, stats.LastFinalizedRound, int64(0), httpResponse)
+		require.Greater(t, stats.BlocksFinalized, int64(0), httpResponse)
+		require.GreaterOrEqual(t, stats.StateHealth, int64(-1), httpResponse)
+		require.Greater(t, stats.CurrentRound, int64(0), httpResponse)
+		require.GreaterOrEqual(t, stats.RoundTimeout, int64(0), httpResponse)
+		require.GreaterOrEqual(t, stats.Timeouts, int64(0), httpResponse)
+		require.Greater(t, stats.AverageBlockSize, 0, httpResponse)
+		require.NotNil(t, stats.NetworkTime, httpResponse)
+	})
+
+	t.Run("Get sharder stats call should return successfully", func(t *testing.T) {
+		t.Parallel()
+		stats, httpResponse, err := v1SharderGetStats(t, util.ConsensusByHttpStatus("200 OK"))
+
+		require.Nil(t, err)
+		require.Equal(t, "200 OK", httpResponse.Status(), httpResponse)
+		require.NotNil(t, stats)
+		require.Greater(t, stats.LastFinalizedRound, int64(0), httpResponse)
+		require.GreaterOrEqual(t, stats.StateHealth, int64(-1), httpResponse)
+		require.Greater(t, stats.AverageBlockSize, 0, httpResponse)
+		require.Greater(t, stats.PrevInvocationCount, uint64(0), httpResponse)
+		require.NotNil(t, stats.PrevInvocationScanTime, uint64(0), httpResponse)
+		require.Greater(t, stats.MeanScanBlockStatsTime, float64(0), httpResponse)
+	})
+}

--- a/tests/api_tests/get_stats_test.go
+++ b/tests/api_tests/get_stats_test.go
@@ -6,15 +6,15 @@ import (
 	"testing"
 )
 
-func TestGetStats(t *testing.T) {
+func TestName(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Get miner stats call should return successfully", func(t *testing.T) {
 		t.Parallel()
-		stats, httpResponse, err := v1MinerGetStats(t, util.ConsensusByHttpStatus("200 OK"))
+		stats, httpResponse, err := v1MinerGetStats(t, util.ConsensusByHttpStatus(util.HttpOkStatus))
 
 		require.Nil(t, err)
-		require.Equal(t, "200 OK", httpResponse.Status(), httpResponse)
+		require.Equal(t, util.HttpOkStatus, httpResponse.Status(), httpResponse)
 		require.NotNil(t, stats)
 		require.Greater(t, stats.BlockFinality, float64(0), httpResponse)
 		require.Greater(t, stats.LastFinalizedRound, int64(0), httpResponse)
@@ -29,10 +29,10 @@ func TestGetStats(t *testing.T) {
 
 	t.Run("Get sharder stats call should return successfully", func(t *testing.T) {
 		t.Parallel()
-		stats, httpResponse, err := v1SharderGetStats(t, util.ConsensusByHttpStatus("200 OK"))
+		stats, httpResponse, err := v1SharderGetStats(t, util.ConsensusByHttpStatus(util.HttpOkStatus))
 
 		require.Nil(t, err)
-		require.Equal(t, "200 OK", httpResponse.Status(), httpResponse)
+		require.Equal(t, util.HttpOkStatus, httpResponse.Status(), httpResponse)
 		require.NotNil(t, stats)
 		require.Greater(t, stats.LastFinalizedRound, int64(0), httpResponse)
 		require.GreaterOrEqual(t, stats.StateHealth, int64(-1), httpResponse)

--- a/tests/api_tests/get_stats_test.go
+++ b/tests/api_tests/get_stats_test.go
@@ -37,8 +37,8 @@ func TestGetStats(t *testing.T) {
 		require.Greater(t, stats.LastFinalizedRound, int64(0), httpResponse)
 		require.GreaterOrEqual(t, stats.StateHealth, int64(-1), httpResponse)
 		require.Greater(t, stats.AverageBlockSize, 0, httpResponse)
-		require.Greater(t, stats.PrevInvocationCount, uint64(0), httpResponse)
+		require.GreaterOrEqual(t, stats.PrevInvocationCount, uint64(0), httpResponse)
 		require.NotNil(t, stats.PrevInvocationScanTime, uint64(0), httpResponse)
-		require.Greater(t, stats.MeanScanBlockStatsTime, float64(0), httpResponse)
+		require.GreaterOrEqual(t, stats.MeanScanBlockStatsTime, float64(0), httpResponse)
 	})
 }

--- a/tests/api_tests/open_challenges_test.go
+++ b/tests/api_tests/open_challenges_test.go
@@ -25,8 +25,8 @@ func TestOpenChallenges(t *testing.T) {
 		require.NotNil(t, blobberRequirements)
 
 		blobberId := (*blobbers)[0]
-		response, err := v1ScrestOpenChallenges(t, STORAGE_SMART_CONTRACT_ADDRESS, blobberId, util.ConsensusByHttpStatus("200 OK"))
-		require.Equal(t, "200 OK", response.Status())
+		response, err := v1ScrestOpenChallenges(t, STORAGE_SMART_CONTRACT_ADDRESS, blobberId, util.ConsensusByHttpStatus(util.HttpOkStatus))
+		require.Equal(t, util.HttpOkStatus, response.Status())
 		require.Nil(t, err)
 		bytesReader := bytes.NewBuffer(response.Body())
 		d := json.NewDecoder(bytesReader)

--- a/tests/api_tests/register_wallet_test.go
+++ b/tests/api_tests/register_wallet_test.go
@@ -25,7 +25,7 @@ func TestRegisterWallet(t *testing.T) {
 		expectedClientId := crypto.Sha3256(publicKeyBytes)
 		require.Nil(t, err, "Unexpected error [%s] occurred registering wallet with http response [%s]", err, rawHttpResponse)
 		require.NotNil(t, registeredWallet, "Registered wallet was unexpectedly nil! with http response [%s]", rawHttpResponse)
-		require.Equal(t, "200 OK", rawHttpResponse.Status())
+		require.Equal(t, util.HttpOkStatus, rawHttpResponse.Status())
 		require.Equal(t, registeredWallet.Id, expectedClientId)
 		require.Equal(t, registeredWallet.PublicKey, keyPair.PublicKey.SerializeToHexStr())
 		require.Greater(t, *registeredWallet.CreationDate, 0, "Creation date is an invalid value!")
@@ -47,7 +47,7 @@ func registerWalletForMnemonic(t *testing.T, mnemonic string) (*model.Wallet, mo
 
 	require.Nil(t, err, "Unexpected error [%s] occurred registering wallet with http response [%s]", err, httpResponse)
 	require.NotNil(t, registeredWallet, "Registered wallet was unexpectedly nil! with http response [%s]", httpResponse)
-	require.Equal(t, "200 OK", httpResponse.Status())
+	require.Equal(t, util.HttpOkStatus, httpResponse.Status())
 	require.Equal(t, registeredWallet.Id, clientId)
 	require.Equal(t, registeredWallet.PublicKey, keyPair.PublicKey.SerializeToHexStr())
 	require.Greater(t, *registeredWallet.CreationDate, 0, "Creation date is an invalid value!")
@@ -63,7 +63,7 @@ func registerWalletForMnemonicWithoutAssertion(t *testing.T, mnemonic string) (*
 	clientId := crypto.Sha3256(publicKeyBytes)
 	walletRequest := model.Wallet{Id: clientId, PublicKey: keyPair.PublicKey.SerializeToHexStr()}
 
-	registeredWallet, httpResponse, err := v1ClientPut(t, walletRequest, util.ConsensusByHttpStatus("200 OK"))
+	registeredWallet, httpResponse, err := v1ClientPut(t, walletRequest, util.ConsensusByHttpStatus(util.HttpOkStatus))
 
 	return registeredWallet, keyPair, httpResponse, err
 }


### PR DESCRIPTION
Add simple API tests for the /v1/miner/stats/get and /v1/sharder/stats/get endpoints 
docs also updated:
<img width="257" alt="image" src="https://user-images.githubusercontent.com/18306778/188234000-6d082156-07f7-435f-a839-dc64d493fd05.png">
