### PR TITLE
Remove `value not present` error from `Miner/Sharder pool info`

### DIFF
--- a/tests/cli_tests/zwalletcli_mn_pool_info_test.go
+++ b/tests/cli_tests/zwalletcli_mn_pool_info_test.go
@@ -113,6 +113,6 @@ func TestMinerSharderPoolInfo(testSetup *testing.T) {
 		}), false)
 		require.NotNil(t, err, "expected error when trying to fetch pool info from invalid id")
 		require.Len(t, output, 1)
-		require.Equal(t, `resource_not_found: can't get miner node: value not present`, output[0])
+		require.Equal(t, `resource_not_found: can't find pool stats`, output[0])
 	})
 }


### PR DESCRIPTION
`value not present` error is removed from `Miner/Sharder pool info` tests as  node lookup has been removed from `/getNodePooStats`

Part of this PR: https://github.com/0chain/0chain/pull/1884