### PR TITLE
miner/sharder block reward changes

### DIFF
--- a/internal/cli/model/model.go
+++ b/internal/cli/model/model.go
@@ -665,16 +665,17 @@ func (r Reward) Int() int {
 
 type RewardProvider struct {
 	Amount      int64  `json:"amount"`
-	BlockNumber int64  `json:"block_number" gorm:"index:idx_block,priority:1"`
-	ProviderId  string `json:"provider_id" gorm:"index:idx_provider,priority:2"`
-	RewardType  Reward `json:"reward_type" gorm:"index:idx_reward_type,priority:3"`
+	BlockNumber int64  `json:"block_number"`
+	ProviderId  string `json:"provider_id"`
+	RewardType  Reward `json:"reward_type"`
 }
 
 type RewardDelegate struct {
 	Amount      int64  `json:"amount"`
-	BlockNumber int64  `json:"block_number" gorm:"index:idx_block,priority:1"`
-	PoolID      string `json:"pool_id" gorm:"index:idx_pool,priority:2"`
-	RewardType  Reward `json:"reward_type" gorm:"index:idx_reward_type,priority:3"`
+	BlockNumber int64  `json:"block_number"`
+	PoolID      string `json:"pool_id"`
+	ProviderID  string `json:"provider_id"`
+	RewardType  Reward `json:"reward_type"`
 }
 
 type EventDBBlock struct {

--- a/tests/cli_tests/miner_block_rewards_test.go
+++ b/tests/cli_tests/miner_block_rewards_test.go
@@ -178,9 +178,11 @@ func TestMinerBlockRewards(testSetup *testing.T) { // nolint:gocyclo // team pre
 				poolsBlockRewarded := make(map[string]int64)
 				roundHistory := history.RoundHistory(t, round)
 				for _, dReward := range roundHistory.DelegateRewards {
-					if _, found := rewards[dReward.PoolID]; !found {
+					if dReward.ProviderID != id {
 						continue
 					}
+					_, isMinerPool := rewards[dReward.PoolID]
+					require.Truef(testSetup, isMinerPool, "round %d, invalid pool id, reward %v", round, dReward)
 					switch dReward.RewardType {
 					case climodel.BlockRewardMiner:
 						_, found := poolsBlockRewarded[dReward.PoolID]
@@ -191,7 +193,7 @@ func TestMinerBlockRewards(testSetup *testing.T) { // nolint:gocyclo // team pre
 					case climodel.FeeRewardMiner:
 						rewards[dReward.PoolID] += dReward.Amount
 					default:
-						require.Failf(t, "reward type %s not paid to miner delegate pools", dReward.RewardType.String())
+						require.Failf(t, "mismatched reward", "round %d, %s not available for miner", round, dReward.RewardType)
 					}
 				}
 				if roundHistory.Block.MinerID != id {

--- a/tests/cli_tests/sharder_block_rewards_test.go
+++ b/tests/cli_tests/sharder_block_rewards_test.go
@@ -165,7 +165,7 @@ func TestSharderBlockRewards(testSetup *testing.T) { // nolint:gocyclo // team p
 
 		// Compare the actual change in rewards to each miner delegate, with the
 		// change expected from the delegate reward table.
-		for i := range sharderIds {
+		for i, id := range sharderIds {
 			delegateBlockReward := int64(float64(bwPerSharder) * (1 - beforeSharders.Nodes[i].Settings.ServiceCharge))
 			numPools := len(afterShardedrs.Nodes[i].StakePool.Pools)
 			rewards := make(map[string]int64, numPools)
@@ -176,9 +176,11 @@ func TestSharderBlockRewards(testSetup *testing.T) { // nolint:gocyclo // team p
 				poolsBlockRewards := make(map[string]int64)
 				roundHistory := history.RoundHistory(t, round)
 				for _, dReward := range roundHistory.DelegateRewards {
-					if _, found := rewards[dReward.PoolID]; !found {
+					if dReward.ProviderID != id {
 						continue
 					}
+					_, isSharderPool := rewards[dReward.PoolID]
+					require.Truef(testSetup, isSharderPool, "round %d, invalid pool id, reward %v", round, dReward)
 					switch dReward.RewardType {
 					case climodel.BlockRewardSharder:
 						_, found := poolsBlockRewards[dReward.PoolID]


### PR DESCRIPTION
Modify miner and sharder block reward test to work with https://github.com/0chain/0chain/pull/2106, which adds provider id to delegate pool rewards.

Requires https://github.com/0chain/0chain/pull/2106