### PR TITLE
Feature/add long running test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Check CI
         id: check-ci
-        uses: 0chain/actions/get-build-state@master
+        uses: 0chain/actions/get-build-state@feature/add-long-running-test-suite
         with:
           github_token: ${{ github.token }}
           repository: "0chain/system_test"
@@ -99,7 +99,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: "Set PR status as pending"
-        uses: 0chain/actions/set-pr-status@master
+        uses: 0chain/actions/set-pr-status@feature/add-long-running-test-suite
         if: steps.findPr.outputs.number && github.event.inputs.test_file_filter == ''
         with:
           pr_number: ${{ steps.findPr.outputs.pr }}
@@ -140,7 +140,7 @@ jobs:
 
       - name: "Deploy 0Chain"
         if: github.event_name == 'push' || github.event.inputs.existing_network == ''
-        uses: 0chain/actions/deploy-0chain@master
+        uses: 0chain/actions/deploy-0chain@feature/add-long-running-test-suite
         with:
           kube_config: ${{ secrets[format('DEV{0}KC', env.RUNNER_NUMBER)] }}
           teardown_condition: "TESTS_PASSED"
@@ -159,7 +159,7 @@ jobs:
           TENDERLY_FORK_ID: ${{ secrets.TENDERLY_FORK_ID }}
 
       - name: "Run System tests"
-        uses: 0chain/actions/run-system-tests@master
+        uses: 0chain/actions/run-system-tests@feature/add-long-running-test-suite
         with:
           network: ${{ env.NETWORK_URL }}
           zbox_cli_branch: ${{ env.ZBOX_BRANCH }}
@@ -167,13 +167,15 @@ jobs:
           svc_account_secret: ${{ secrets.SVC_ACCOUNT_SECRET }}
           deploy_report_page: true
           archive_results: true
-          run_flaky_tests: true
+          run_flaky_tests: false
+          run_api_tests: false
+          run_cli_tests: false
           test_file_filter: ${{ env.TEST_FILE_FILTER }}
           TENDERLY_FORK_ID: ${{ secrets.TENDERLY_FORK_ID }}
 
       - name: "Set PR status as ${{ job.status }}"
         if: ${{ (success() || failure()) && steps.findPr.outputs.number && github.event.inputs.test_file_filter == '' }}
-        uses: 0chain/actions/set-pr-status@master
+        uses: 0chain/actions/set-pr-status@feature/add-long-running-test-suite
         with:
           pr_number: ${{ steps.findPr.outputs.pr }}
           description: "System tests with default config ${{ job.status }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
           svc_account_secret: ${{ secrets.SVC_ACCOUNT_SECRET }}
           deploy_report_page: true
           archive_results: true
-          run_flaky_tests: false
+          run_flaky_tests: true
           run_api_system_tests: true
           run_cli_system_tests: true
           run_tokenomics_system_tests: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,9 @@ jobs:
           deploy_report_page: true
           archive_results: true
           run_flaky_tests: false
-          run_api_tests: false
-          run_cli_tests: false
+          run_api_system_tests: false
+          run_cli_system_tests: false
+          run_tokenomics_system_tests: truw
           test_file_filter: ${{ env.TEST_FILE_FILTER }}
           TENDERLY_FORK_ID: ${{ secrets.TENDERLY_FORK_ID }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Check CI
         id: check-ci
-        uses: 0chain/actions/get-build-state@feature/add-long-running-test-suite
+        uses: 0chain/actions/get-build-state@master
         with:
           github_token: ${{ github.token }}
           repository: "0chain/system_test"
@@ -99,7 +99,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: "Set PR status as pending"
-        uses: 0chain/actions/set-pr-status@feature/add-long-running-test-suite
+        uses: 0chain/actions/set-pr-status@master
         if: steps.findPr.outputs.number && github.event.inputs.test_file_filter == ''
         with:
           pr_number: ${{ steps.findPr.outputs.pr }}
@@ -140,7 +140,7 @@ jobs:
 
       - name: "Deploy 0Chain"
         if: github.event_name == 'push' || github.event.inputs.existing_network == ''
-        uses: 0chain/actions/deploy-0chain@feature/add-long-running-test-suite
+        uses: 0chain/actions/deploy-0chain@master
         with:
           kube_config: ${{ secrets[format('DEV{0}KC', env.RUNNER_NUMBER)] }}
           teardown_condition: "TESTS_PASSED"
@@ -159,7 +159,7 @@ jobs:
           TENDERLY_FORK_ID: ${{ secrets.TENDERLY_FORK_ID }}
 
       - name: "Run System tests"
-        uses: 0chain/actions/run-system-tests@feature/add-long-running-test-suite
+        uses: 0chain/actions/run-system-tests@master
         with:
           network: ${{ env.NETWORK_URL }}
           zbox_cli_branch: ${{ env.ZBOX_BRANCH }}
@@ -168,15 +168,15 @@ jobs:
           deploy_report_page: true
           archive_results: true
           run_flaky_tests: false
-          run_api_system_tests: false
-          run_cli_system_tests: false
-          run_tokenomics_system_tests: truw
+          run_api_system_tests: true
+          run_cli_system_tests: true
+          run_tokenomics_system_tests: true
           test_file_filter: ${{ env.TEST_FILE_FILTER }}
           TENDERLY_FORK_ID: ${{ secrets.TENDERLY_FORK_ID }}
 
       - name: "Set PR status as ${{ job.status }}"
         if: ${{ (success() || failure()) && steps.findPr.outputs.number && github.event.inputs.test_file_filter == '' }}
-        uses: 0chain/actions/set-pr-status@feature/add-long-running-test-suite
+        uses: 0chain/actions/set-pr-status@master
         with:
           pr_number: ${{ steps.findPr.outputs.pr }}
           description: "System tests with default config ${{ job.status }}"

--- a/internal/tokenomics/util/config/config.go
+++ b/internal/tokenomics/util/config/config.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"log"
+	"os"
+
+	"gopkg.in/yaml.v3" //nolint
+)
+
+// ConfigPathEnv contains name of env variable
+const ConfigPathEnv = "CONFIG_PATH"
+
+// DefaultConfigPath contains default value of ConfigPathEnv
+const DefaultConfigPath = "./config/tokenomics_tests_config.yaml"
+
+type Config struct {
+	BlockWorker            string `yaml:"block_worker"`
+	ZboxUrl                string `yaml:"0box_url"`
+	ZboxPhoneNumber        string `yaml:"0box_phone_number"`
+	DefaultTestCaseTimeout string `yaml:"default_test_case_timeout"`
+	ZS3ServerUrl           string `yaml:"zs3_server_url"`
+}
+
+func Parse(configPath string) *Config {
+	var result *Config
+
+	file, err := os.ReadFile(configPath)
+	if err != nil {
+		log.Fatalln("Failed to read config file! due to error: " + err.Error())
+	}
+	err = yaml.Unmarshal(file, &result) //nolint
+	if err != nil {
+		log.Fatalln("failed to deserialise config file due to error: " + err.Error())
+	}
+
+	return result
+}

--- a/tests/tokenomics_tests/config/tokenomics_tests_config.yaml
+++ b/tests/tokenomics_tests/config/tokenomics_tests_config.yaml
@@ -1,12 +1,12 @@
 block_worker: https://dev.0chain.net
-confirmation_chain_length: 3
+0box_url: https://0box.dev.0chain.net
+zs3_server_url: https://dev.0chain.net/zs3server/
 ethereum_node_url: "https://rpc.tenderly.co/fork/e753f650-9968-4f58-af77-5f02ace53cdc"
+confirmation_chain_length: 3
 min_confirmation: 50
 min_submit: 50
 signature_scheme: bls0chain
 store_unlock_duration_sec: 2
 ethereum_address: 0xD8c9156e782C68EE671C09b6b92de76C97948432
-0box_url: https://0box.dev.0chain.net
 0box_phone_number: +917696229925
-default_test_case_timeout: 120s
-zs3_server_url: https://dev.0chain.net/zs3server/
+default_test_case_timeout: 300s

--- a/tests/tokenomics_tests/config/tokenomics_tests_config.yaml
+++ b/tests/tokenomics_tests/config/tokenomics_tests_config.yaml
@@ -1,0 +1,12 @@
+block_worker: https://demo.zus.network/dns
+confirmation_chain_length: 3
+ethereum_node_url: "https://rpc.tenderly.co/fork/e753f650-9968-4f58-af77-5f02ace53cdc"
+min_confirmation: 50
+min_submit: 50
+signature_scheme: bls0chain
+store_unlock_duration_sec: 2
+ethereum_address: 0xD8c9156e782C68EE671C09b6b92de76C97948432
+0box_url: https://0box.dev.devnet-0chain.net
+0box_phone_number: +917696229925
+default_test_case_timeout: 120s
+zs3_server_url: https://dev.0chain.net/zs3server/

--- a/tests/tokenomics_tests/config/tokenomics_tests_config.yaml
+++ b/tests/tokenomics_tests/config/tokenomics_tests_config.yaml
@@ -1,4 +1,4 @@
-block_worker: https://demo.zus.network/dns
+block_worker: https://dev.0chain.net
 confirmation_chain_length: 3
 ethereum_node_url: "https://rpc.tenderly.co/fork/e753f650-9968-4f58-af77-5f02ace53cdc"
 min_confirmation: 50
@@ -6,7 +6,7 @@ min_submit: 50
 signature_scheme: bls0chain
 store_unlock_duration_sec: 2
 ethereum_address: 0xD8c9156e782C68EE671C09b6b92de76C97948432
-0box_url: https://0box.dev.devnet-0chain.net
+0box_url: https://dev.0chain.net
 0box_phone_number: +917696229925
 default_test_case_timeout: 120s
 zs3_server_url: https://dev.0chain.net/zs3server/

--- a/tests/tokenomics_tests/config/tokenomics_tests_config.yaml
+++ b/tests/tokenomics_tests/config/tokenomics_tests_config.yaml
@@ -6,7 +6,7 @@ min_submit: 50
 signature_scheme: bls0chain
 store_unlock_duration_sec: 2
 ethereum_address: 0xD8c9156e782C68EE671C09b6b92de76C97948432
-0box_url: https://dev.0chain.net
+0box_url: https://0box.dev.0chain.net
 0box_phone_number: +917696229925
 default_test_case_timeout: 120s
 zs3_server_url: https://dev.0chain.net/zs3server/

--- a/tests/tokenomics_tests/main_test.go
+++ b/tests/tokenomics_tests/main_test.go
@@ -1,0 +1,35 @@
+package tokenomics_tests
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/0chain/system_test/internal/api/util/test"
+	"github.com/0chain/system_test/internal/tokenomics/util/config"
+)
+
+var (
+	parsedConfig *config.Config
+)
+
+func TestMain(m *testing.M) {
+	configPath, ok := os.LookupEnv(config.ConfigPathEnv)
+	if !ok {
+		configPath = config.DefaultConfigPath
+		log.Printf("CONFIG_PATH environment variable is not set so has defaulted to [%v]", configPath)
+	}
+
+	parsedConfig = config.Parse(configPath)
+
+	defaultTestTimeout, err := time.ParseDuration(parsedConfig.DefaultTestCaseTimeout)
+	if err != nil {
+		log.Printf("Default test case timeout could not be parsed so has defaulted to [%v]", test.DefaultTestTimeout)
+	} else {
+		test.DefaultTestTimeout = defaultTestTimeout
+		log.Printf("Default test case timeout is [%v]", test.DefaultTestTimeout)
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Adds new test suite - tokenomics tests for long-running, non-user-facing tests such as block/blobber rewards and token movement.
Next PR will migrate existing tests from CLI and API suites to this long running suite.
We can then run these on staging only or on demand/nighty basis
Hopefully this will speed up dev feedback 

Actions PR:
https://github.com/0chain/actions/pull/126
<img width="503" alt="image" src="https://user-images.githubusercontent.com/18306778/227668486-0d14c046-f7ea-4206-85c1-acddcda456c4.png">
