### PR TITLE
Minor patches

### DIFF
--- a/tests/cli_tests/zboxcli_collect_rewards_test.go
+++ b/tests/cli_tests/zboxcli_collect_rewards_test.go
@@ -29,7 +29,7 @@ func TestBlobberCollectRewards(testSetup *testing.T) {
 		wallet, err := getWallet(t, configPath)
 		require.Nil(t, err, "error getting wallet")
 
-		output, err = executeFaucetWithTokens(t, configPath, 2.0)
+		output, err = executeFaucetWithTokens(t, configPath, 9.0)
 		require.Nil(t, err, "faucet execution failed", strings.Join(output, "\n"))
 
 		blobbers := []climodel.BlobberInfo{}
@@ -46,7 +46,7 @@ func TestBlobberCollectRewards(testSetup *testing.T) {
 		// Stake tokens against this blobber
 		output, err = stakeTokens(t, configPath, createParams(map[string]interface{}{
 			"blobber_id": blobber.Id,
-			"tokens":     1.0,
+			"tokens":     5.0,
 		}), true)
 		require.Nil(t, err, "Error staking tokens", strings.Join(output, "\n"))
 		require.Len(t, output, 1)

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -24,7 +24,7 @@ func TestFileRename(testSetup *testing.T) { // nolint:gocyclo // team preference
 
 	t.Parallel()
 
-	t.Run("rename file", func(t *test.SystemTest) {
+	t.Run("rename file should work", func(t *test.SystemTest) {
 		allocSize := int64(2048)
 		fileSize := int64(256)
 
@@ -493,7 +493,7 @@ func TestFileRename(testSetup *testing.T) { // nolint:gocyclo // team preference
 		createAllocationTestTeardown(t, allocationID)
 	})
 
-	t.RunWithTimeout("rename root path should fail", 60*time.Second, func(t *test.SystemTest) {
+	t.Run("rename root path should fail", func(t *test.SystemTest) {
 		allocSize := int64(2048)
 
 		remotePath := "/"
@@ -507,7 +507,7 @@ func TestFileRename(testSetup *testing.T) { // nolint:gocyclo // team preference
 			"allocation": allocationID,
 			"remotepath": remotePath,
 			"destname":   destName,
-		}, true)
+		}, false)
 		require.NotNil(t, err, strings.Join(output, "\n"))
 		require.Len(t, output, 1)
 		require.Equal(t, "invalid_operation: cannot rename root path", output[0])


### PR DESCRIPTION
- Increases stake amount to avoid failures related to `stake_pool_lock_failed: too small stake to lock:`. This can happen is bl-update worked but cleanup didn't get confirmed
- Changes retries to false when expecting failure in a retry test