### PR TITLE
Edited path to the correct location for running tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Modify the ```block_worker``` field in ```./tests/cli_tests/config/zbox_config.y
 To run the entire test suite (minus tests for known broken features) run:
 
 ```bash
-cp $ZBOX_LOCATION ./tests/cli/ # Copy zbox CLI to test folder
-cp $ZWALLET_LOCATION ./tests/cli/ # Copy zwallet CLI to test folder
-cd ./tests/cli/
+cp $ZBOX_LOCATION ./tests/cli_tests/ # Copy zbox CLI to test folder
+cp $ZWALLET_LOCATION ./tests/cli_tests/ # Copy zwallet CLI to test folder
+cd ./tests/cli_tests/
 go test -run "^Test[^___]*$" ./... -v
 ```
 Debug logging can be achieved by running


### PR DESCRIPTION
The location to copy zbox cli and zwallet clis was set to tests/cli/ while there is no such directory in system_test repo. Edited it to tests/cli_tests directory