### PR TITLE
Add Sleep after upload 

### DIFF
--- a/tests/cli_tests/zboxcli_file_move_test.go
+++ b/tests/cli_tests/zboxcli_file_move_test.go
@@ -271,7 +271,7 @@ func TestFileMove(testSetup *testing.T) { // nolint:gocyclo // team preference i
 		localpath := uploadRandomlyGeneratedFile(t, allocationID, "/", fileSize)
 
 		// Wait for write marker to be redeemed
-		time.Sleep(10 * time.Second)
+		time.Sleep(16 * time.Second)
 		initialAllocation := getAllocation(t, allocationID)
 
 		// Move file

--- a/tests/cli_tests/zboxcli_file_move_test.go
+++ b/tests/cli_tests/zboxcli_file_move_test.go
@@ -271,7 +271,7 @@ func TestFileMove(testSetup *testing.T) { // nolint:gocyclo // team preference i
 		localpath := uploadRandomlyGeneratedFile(t, allocationID, "/", fileSize)
 
 		// Wait for write marker to be redeemed
-		time.Sleep(25 * time.Second)
+		time.Sleep(16 * time.Second)
 		initialAllocation := getAllocation(t, allocationID)
 
 		// Move file

--- a/tests/cli_tests/zboxcli_file_move_test.go
+++ b/tests/cli_tests/zboxcli_file_move_test.go
@@ -271,7 +271,7 @@ func TestFileMove(testSetup *testing.T) { // nolint:gocyclo // team preference i
 		localpath := uploadRandomlyGeneratedFile(t, allocationID, "/", fileSize)
 
 		// Wait for write marker to be redeemed
-		time.Sleep(16 * time.Second)
+		time.Sleep(25 * time.Second)
 		initialAllocation := getAllocation(t, allocationID)
 
 		// Move file

--- a/tests/cli_tests/zboxcli_file_move_test.go
+++ b/tests/cli_tests/zboxcli_file_move_test.go
@@ -270,6 +270,8 @@ func TestFileMove(testSetup *testing.T) { // nolint:gocyclo // team preference i
 		// Upload 1 MB file
 		localpath := uploadRandomlyGeneratedFile(t, allocationID, "/", fileSize)
 
+		// Wait for write marker to be redeemed
+		time.Sleep(10 * time.Second)
 		initialAllocation := getAllocation(t, allocationID)
 
 		// Move file

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -468,7 +468,7 @@ func TestFileRename(testSetup *testing.T) { // nolint:gocyclo // team preference
 		localpath := uploadRandomlyGeneratedFile(t, allocationID, "/", fileSize)
 
 		// Wait for write marker to be redeemed
-		time.Sleep(25 * time.Second)
+		time.Sleep(16 * time.Second)
 		// Get initial write pool
 		initialAllocation := getAllocation(t, allocationID)
 
@@ -675,6 +675,7 @@ func TestFileRename(testSetup *testing.T) { // nolint:gocyclo // team preference
 		localpath := uploadRandomlyGeneratedFile(t, allocationID, "/", fileSize)
 
 		// Get initial write pool
+		time.Sleep(16 * time.Second)
 		initialAllocation := getAllocation(t, allocationID)
 
 		// Rename file

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -468,7 +468,7 @@ func TestFileRename(testSetup *testing.T) { // nolint:gocyclo // team preference
 		localpath := uploadRandomlyGeneratedFile(t, allocationID, "/", fileSize)
 
 		// Wait for write marker to be redeemed
-		time.Sleep(16 * time.Second)
+		time.Sleep(25 * time.Second)
 		// Get initial write pool
 		initialAllocation := getAllocation(t, allocationID)
 

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -467,6 +467,8 @@ func TestFileRename(testSetup *testing.T) { // nolint:gocyclo // team preference
 		// Upload 1 MB file
 		localpath := uploadRandomlyGeneratedFile(t, allocationID, "/", fileSize)
 
+		// Wait for write marker to be redeemed
+		time.Sleep(10 * time.Second)
 		// Get initial write pool
 		initialAllocation := getAllocation(t, allocationID)
 

--- a/tests/cli_tests/zboxcli_file_rename_test.go
+++ b/tests/cli_tests/zboxcli_file_rename_test.go
@@ -468,7 +468,7 @@ func TestFileRename(testSetup *testing.T) { // nolint:gocyclo // team preference
 		localpath := uploadRandomlyGeneratedFile(t, allocationID, "/", fileSize)
 
 		// Wait for write marker to be redeemed
-		time.Sleep(10 * time.Second)
+		time.Sleep(16 * time.Second)
 		// Get initial write pool
 		initialAllocation := getAllocation(t, allocationID)
 


### PR DESCRIPTION
We need to wait for some time after uploading the file, so blobber can redeem the writemarker.