### PR TITLE
unskip fee rewards

### DIFF
--- a/tests/cli_tests/miner_fee_rewards_test.go
+++ b/tests/cli_tests/miner_fee_rewards_test.go
@@ -15,8 +15,6 @@ import (
 func TestMinerFeeRewards(testSetup *testing.T) { // nolint:gocyclo // team preference is to have codes all within test.
 	t := test.NewSystemTest(testSetup)
 
-	t.Skip("wait for duplicate transaction issue to be solved, https://github.com/0chain/0chain/issues/2348")
-
 	// Take a snapshot of the chains miners, repeat a transaction with a fee a few times,
 	// take another snapshot.
 	// Examine the rewards paid between the two snapshot and confirm the self-consistency

--- a/tests/cli_tests/sharder_fee_rewards_test.go
+++ b/tests/cli_tests/sharder_fee_rewards_test.go
@@ -14,8 +14,6 @@ import (
 func TestSharderFeeRewards(testSetup *testing.T) { // nolint:gocyclo // team preference is to have codes all within test.
 	t := test.NewSystemTest(testSetup)
 
-	t.Skip("wait for duplicate transaction issue to be solved, https://github.com/0chain/0chain/issues/2348")
-
 	// Take a snapshot of the chains sharders, then repeat a transaction with a fee a few times, take another snapshot.
 	// Examine the rewards paid between the two snapshot and confirm the self-consistency
 	// of the reward payments


### PR DESCRIPTION
The PRs below fix some issues that were stopping fee rewards tests from working. This unskips these tests.

zwallet: https://github.com/0chain/zwalletcli/pull/274/files
gosdk: https://github.com/0chain/gosdk/pull/1085
0chain: https://github.com/0chain/0chain/pull/2577