### PR TITLE
Enable logging for s3 migration tests similar to zbox cli tests 

### DIFF
--- a/tests/cli_tests/0_s3mgrt_migrate_test.go
+++ b/tests/cli_tests/0_s3mgrt_migrate_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/0chain/system_test/internal/api/util/test"
 	cliutils "github.com/0chain/system_test/internal/cli/util"
@@ -244,5 +245,5 @@ func Test0S3Migration(testSetup *testing.T) {
 
 func migrateFromS3(t *test.SystemTest, cliConfigFilename, params string) ([]string, error) {
 	t.Logf("Migrating S3 bucket to Zus...")
-	return cliutils.RunCommandWithoutRetry(fmt.Sprintf("./s3mgrt migrate --silent --configDir ./config --config %s --network %s %s", cliConfigFilename, cliConfigFilename, params))
+	return cliutils.RunCommand(t, fmt.Sprintf("./s3mgrt migrate --silent --configDir ./config --config %s --network %s %s", cliConfigFilename, cliConfigFilename, params), 1, time.Second*2)
 }


### PR DESCRIPTION
Retry failed cmd with logging enabled.