### PR TITLE
fix: TestBlobberConfigUpdate/update_without_blobber_ID_should_fail

### DIFF
--- a/tests/cli_tests/zboxcli_blobber_config_update_test.go
+++ b/tests/cli_tests/zboxcli_blobber_config_update_test.go
@@ -141,7 +141,7 @@ func TestBlobberConfigUpdate(testSetup *testing.T) {
 
 		output, err := updateBlobberInfo(t, configPath, "")
 		require.NotNil(t, err, strings.Join(output, "\n"))
-		require.Len(t, output, 28)
+		require.Len(t, output, 30, "Expected length", len(output))
 		require.Equalf(t, "Error: required flag(s) \"blobber_id\" not set", output[0], "output was: %s", output[0])
 	})
 


### PR DESCRIPTION
fix: output lenght in TestBlobberConfigUpdate/update_without_blobber_ID_should_fail